### PR TITLE
Fix db path to avoid Git resets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 db.json
+mnt/data/db.json

--- a/README.md
+++ b/README.md
@@ -10,8 +10,15 @@ This is a simple leave management system built with Node.js and Express.
    ```
 2. (Optional) Import employees from the provided CSV:
    ```bash
-   node import.js
-   ```
+ node import.js
+  ```
+
+## Database Storage
+
+The application uses a JSON file database. By default it is stored at
+`mnt/data/db.json`. You can change the location by setting the `DB_PATH`
+environment variable. The database file is listed in `.gitignore` to prevent
+it from being overwritten when pulling updates from GitHub.
 
 ## Email Notifications
 

--- a/db.js
+++ b/db.js
@@ -1,16 +1,25 @@
 // leave-system/db.js
 const { Low } = require('lowdb');
 const { JSONFile } = require('lowdb/node');
+const fs = require('fs');
+const path = require('path');
 
-// 1. Tell lowdb to use your db.json file, and give it default data:
-const adapter = new JSONFile('db.json');
+// --- Database path setup ---
+const DATA_DIR = path.join(__dirname, 'mnt', 'data');
+const DB_PATH = process.env.DB_PATH || path.join(DATA_DIR, 'db.json');
+if (!fs.existsSync(DATA_DIR)) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+
+// Tell lowdb to use the persistent db.json file and provide default data
+const adapter = new JSONFile(DB_PATH);
 const defaultData = { employees: [], applications: [] };
 const db = new Low(adapter, defaultData);
 
-// 2. Initialization function (reads the file and writes defaults if missing):
+// Initialization function (reads the file and writes defaults if missing)
 async function init() {
   await db.read();   // loads db.data (or defaultData if file was empty)
   await db.write();  // ensures file exists with defaultData on first run
 }
 
-module.exports = { db, init };
+module.exports = { db, init, DB_PATH };

--- a/import.js
+++ b/import.js
@@ -1,6 +1,7 @@
 // import.js
 const fs    = require('fs');
 const path  = require('path');
+const { DB_PATH } = require('./db');
 // Use the supported sync parser entrypoint:
 const { parse } = require('csv-parse/sync');
 
@@ -36,9 +37,8 @@ const db = {
 
 // 5. Write it out
 fs.writeFileSync(
-  path.join(__dirname, 'db.json'),
+  DB_PATH,
   JSON.stringify(db, null, 2),
   'utf-8'
 );
-
-console.log(`Imported ${employees.length} employees into db.json`);
+console.log(`Imported ${employees.length} employees into ${DB_PATH}`);

--- a/mnt/data/db.json
+++ b/mnt/data/db.json
@@ -1,4 +1,0 @@
-{
-  "employees": [],
-  "applications": []
-}

--- a/server.js
+++ b/server.js
@@ -5,11 +5,10 @@ const bodyParser = require('body-parser');
 const path = require('path');
 const fs = require('fs');
 const nodemailer = require('nodemailer');
-const { db, init } = require('./db');
+const { db, init, DB_PATH } = require('./db');
 
 const app = express();
 
-const DB_PATH = path.join(__dirname, 'db.json');
 
 // Utility: Load and Save DB
 function loadDB() {


### PR DESCRIPTION
## Summary
- store database at `mnt/data/db.json` and create folder when missing
- read the DB path from `db.js` in server and import script
- ignore `mnt/data/db.json` so pulls don't overwrite data
- document database storage in README

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_686bddaf4688832eaa9a44e0f98d67ca