### PR TITLE
Add CSV employee bulk upload

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -174,9 +174,9 @@
             <span class="font-bold text-green-700 text-lg mr-1" id="activeCountNum">0</span>
             <span class="text-green-700">Active Employees</span>
           </div>
-          <button id="addEmployeeBtn" class="ml-auto bg-blue-600 text-white font-semibold px-4 py-2 rounded shadow hover:bg-blue-700 transition">
-            + Add Employee
-          </button>
+          <button id="csvUploadBtn" class="ml-auto bg-blue-500 text-white font-semibold px-4 py-2 rounded shadow hover:bg-blue-600 transition">Upload CSV</button>
+          <button id="addEmployeeBtn" class="ml-2 bg-blue-600 text-white font-semibold px-4 py-2 rounded shadow hover:bg-blue-700 transition">+ Add Employee</button>
+          <input id="csvInput" type="file" accept=".csv" class="hidden">
         </div>
         <div class="overflow-x-auto mb-6" style="overflow-x:auto; min-height:40px;">
           <table id="empTable" class="min-w-max w-full table-auto border border-gray-400 divide-y-2 divide-gray-400 divide-x whitespace-nowrap bg-white rounded-lg shadow">

--- a/public/index.js
+++ b/public/index.js
@@ -128,6 +128,24 @@ async function init() {
     const fields = await getDynamicEmployeeFields();
     openEmpDrawer({title: 'Add Employee', fields});
   };
+  const csvBtn = document.getElementById('csvUploadBtn');
+  const csvInput = document.getElementById('csvInput');
+  if (csvBtn && csvInput) {
+    csvBtn.onclick = () => csvInput.click();
+    csvInput.onchange = async ev => {
+      const file = ev.target.files[0];
+      if (!file) return;
+      const text = await file.text();
+      await fetch(API + '/employees/bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/csv' },
+        body: text
+      });
+      ev.target.value = '';
+      await loadEmployeesManage();
+      await loadEmployeesPortal();
+    };
+  }
   document.getElementById('drawerCancelBtn').onclick = closeEmpDrawer;
   document.getElementById('drawerCloseBtn').onclick = closeEmpDrawer;
   document.getElementById('empDrawerForm').onsubmit = onEmpDrawerSubmit;


### PR DESCRIPTION
## Summary
- add `csv-parse` to server
- create `/employees/bulk` endpoint for CSV uploads
- support CSV import from Employee Management panel

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_686be4a86220832e9ab7b608292938a1