### PR TITLE
Add env admin login

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ The server can send email notifications when leave applications are submitted or
 - `SMTP_FROM` - (optional) address used in the `From` header
 
 If these variables are not set, emails will be skipped.
+
+## Admin Login
+
+When the database is empty, you can still log in using a special admin
+account to upload employee data. Configure the credentials with the
+`ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables. They default to
+`admin@brillar.io` and `admin`.


### PR DESCRIPTION
## Summary
- allow admin login using `ADMIN_EMAIL`/`ADMIN_PASSWORD` environment variables
- document new admin login variables in README

## Testing
- `npm start` (server started successfully)


------
https://chatgpt.com/codex/tasks/task_e_686c96120808832eb63685e17c45ca21