### PR TITLE
Add automatic user creation on employee import

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ This is a simple leave management system built with Node.js and Express.
  node import.js
   ```
 
+### CSV Columns
+
+When uploading employees via CSV or the `import.js` script, include an `Email`
+column and a `Role` column. The role should be either `employee` or `manager`.
+User accounts will be created automatically with the email address and the
+default password `brillar`.
+
 ## Database Storage
 
 The application uses a JSON file database. By default it is stored at

--- a/db.js
+++ b/db.js
@@ -13,12 +13,14 @@ if (!fs.existsSync(DATA_DIR)) {
 
 // Tell lowdb to use the persistent db.json file and provide default data
 const adapter = new JSONFile(DB_PATH);
-const defaultData = { employees: [], applications: [] };
+const defaultData = { employees: [], applications: [], users: [] };
 const db = new Low(adapter, defaultData);
 
 // Initialization function (reads the file and writes defaults if missing)
 async function init() {
   await db.read();   // loads db.data (or defaultData if file was empty)
+  // Ensure all collections exist
+  if (!db.data.users) db.data.users = [];
   await db.write();  // ensures file exists with defaultData on first run
 }
 

--- a/import.js
+++ b/import.js
@@ -16,8 +16,9 @@ const rows = parse(csvText, {
 });
 
 // 3. Map rows → your JSON structure, pulling Name into name:
+const start = Date.now();
 const employees = rows.map((row, i) => ({
-  id: Date.now() + i,
+  id: start + i,
   name: row['Name'],   // ← ensure this matches your CSV header exactly
   status: row.Status?.toLowerCase() === 'inactive' ? 'inactive' : 'active',
   leaveBalances: {
@@ -29,10 +30,19 @@ const employees = rows.map((row, i) => ({
   ...row
 }));
 
+const users = rows.map((row, i) => ({
+  id: start + i,
+  email: row['Email'],
+  password: 'brillar',
+  role: row['Role']?.toLowerCase() === 'manager' ? 'manager' : 'employee',
+  employeeId: start + i
+}));
+
 // 4. Build the final DB object
 const db = {
   employees,
-  applications: []
+  applications: [],
+  users
 };
 
 // 5. Write it out

--- a/server.js
+++ b/server.js
@@ -133,6 +133,19 @@ init().then(() => {
     const id = Date.now();
     const payload = req.body;
     db.data.employees.push({ id, ...payload });
+    const emailKey = Object.keys(payload).find(k => k.toLowerCase() === 'email');
+    const roleKey = Object.keys(payload).find(k => k.toLowerCase() === 'role');
+    const email = emailKey ? payload[emailKey] : undefined;
+    if (email) {
+      const role = payload[roleKey]?.toLowerCase() === 'manager' ? 'manager' : 'employee';
+      db.data.users.push({
+        id,
+        email,
+        password: 'brillar',
+        role,
+        employeeId: id
+      });
+    }
     await db.write();
     res.status(201).json({ id, ...payload });
   });
@@ -150,6 +163,8 @@ init().then(() => {
         const annualKey = Object.keys(row).find(k => k.toLowerCase().includes('annual'));
         const casualKey = Object.keys(row).find(k => k.toLowerCase().includes('casual'));
         const medicalKey = Object.keys(row).find(k => k.toLowerCase().includes('medical'));
+        const emailKey = Object.keys(row).find(k => k.toLowerCase() === 'email');
+        const roleKey = Object.keys(row).find(k => k.toLowerCase() === 'role');
         const emp = {
           id,
           name: row[nameKey] || '',
@@ -162,6 +177,17 @@ init().then(() => {
           ...row
         };
         db.data.employees.push(emp);
+        const email = emailKey ? row[emailKey] : undefined;
+        if (email) {
+          const role = row[roleKey]?.toLowerCase() === 'manager' ? 'manager' : 'employee';
+          db.data.users.push({
+            id,
+            email,
+            password: 'brillar',
+            role,
+            employeeId: id
+          });
+        }
       });
       await db.write();
       res.status(201).json({ added: rows.length });


### PR DESCRIPTION
## Summary
- auto-create user accounts when employees are created via CSV or API
- include default `users` collection in database
- update import script to populate users
- document CSV columns and default password

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ce1c398b0832e821a85a8d80a1d7a