### PR TITLE
Add leave summary CSV export

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -246,6 +246,9 @@
           <svg class="h-8 w-8 text-purple-400 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 3h18v18H3z"/></svg>
           Leave Report
         </h2>
+        <div class="mb-4">
+          <button id="exportLeavesBtn" class="bg-blue-500 text-white font-semibold px-4 py-2 rounded shadow hover:bg-blue-600 transition">Export Leaves</button>
+        </div>
         <div class="overflow-x-auto" style="overflow-x:auto;">
           <table id="leaveReportTable" class="min-w-max w-full table-auto border border-gray-400 divide-y-2 divide-gray-400 divide-x whitespace-nowrap bg-white rounded-lg shadow">
             <thead>

--- a/public/index.js
+++ b/public/index.js
@@ -158,6 +158,12 @@ async function init() {
       await loadEmployeesPortal();
     };
   }
+  const exportBtn = document.getElementById('exportLeavesBtn');
+  if (exportBtn) {
+    exportBtn.onclick = () => {
+      window.open(API + '/leave-report/export', '_blank');
+    };
+  }
   document.getElementById('drawerCancelBtn').onclick = closeEmpDrawer;
   document.getElementById('drawerCloseBtn').onclick = closeEmpDrawer;
   document.getElementById('empDrawerForm').onsubmit = onEmpDrawerSubmit;


### PR DESCRIPTION
## Summary
- enable exporting leave report data to CSV
- add export button to Leave Report tab

## Testing
- `npm run lint` *(fails: Missing script)*
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_6874bf01755c832e84dca8a6b6ae4560