### PR TITLE
Add Microsoft SSO option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,16 @@ When the database is empty, you can still log in using a special admin
 account to upload employee data. Configure the credentials with the
 `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables. They default to
 `admin@brillar.io` and `admin`.
+
+## Microsoft SSO
+
+To allow users to sign in using their Office&nbsp;365 account, configure Azure AD
+OAuth credentials with the following environment variables:
+
+- `MS_CLIENT_ID` – Azure application client ID
+- `MS_CLIENT_SECRET` – Azure application client secret
+- `MS_TENANT` – tenant ID (default `common`)
+- `MS_REDIRECT_URI` – callback URL (default
+  `http://localhost:3000/auth/microsoft/callback`)
+
+When enabled, the login page shows a **Sign in with Microsoft&nbsp;365** button.

--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,9 @@
         <button type="submit" class="w-full mt-2 py-2 rounded-lg bg-gradient-to-r from-cyan-400 to-cyan-600 hover:from-cyan-500 hover:to-cyan-700 text-white font-bold shadow-lg text-lg tracking-wide transition">
           Sign In
         </button>
+        <button id="msLoginBtn" type="button" class="w-full py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-bold shadow text-lg tracking-wide transition">
+          Sign in with Microsoft 365
+        </button>
         <div id="loginError" class="hidden text-red-600 mt-2 text-center"></div>
       </form>
     </div>

--- a/public/index.js
+++ b/public/index.js
@@ -3,6 +3,15 @@
 let currentUser = null;
 
 document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('token')) {
+    localStorage.setItem('brillar_token', params.get('token'));
+    try {
+      currentUser = JSON.parse(decodeURIComponent(params.get('user')));
+      localStorage.setItem('brillar_user', JSON.stringify(currentUser));
+    } catch {}
+    window.history.replaceState({}, document.title, '/');
+  }
   if (!localStorage.getItem('brillar_token')) {
     document.getElementById('loginPage').classList.remove('hidden');
     document.getElementById('logoutBtn').classList.add('hidden');
@@ -47,6 +56,12 @@ document.getElementById('loginForm').onsubmit = async function(ev) {
     document.getElementById('loginError').textContent = 'Invalid email or password';
     document.getElementById('loginError').classList.remove('hidden');
   }
+};
+
+// Microsoft SSO button
+const msBtn = document.getElementById('msLoginBtn');
+if (msBtn) msBtn.onclick = () => {
+  window.location.href = '/auth/microsoft';
 };
 
 // Logout logic


### PR DESCRIPTION
## Summary
- add configuration options for Microsoft SSO in the server
- implement `/auth/microsoft` and `/auth/microsoft/callback` routes
- update login page with a "Sign in with Microsoft 365" button
- parse SSO callback tokens in the front-end and login the user
- document new environment variables in `README`

## Testing
- `npm install`
- `node server.js` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_68784feffbf0832ea20144d2e22eb00e