### PR TITLE
Add title and location to leave reports

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -257,6 +257,8 @@
             <thead>
               <tr>
                 <th class="px-4 py-2 font-medium bg-gray-50">Name</th>
+                <th class="px-4 py-2 font-medium bg-gray-50">Title</th>
+                <th class="px-4 py-2 font-medium bg-gray-50">Location</th>
                 <th class="px-4 py-2 font-medium bg-gray-50">Total Days</th>
                 <th class="px-4 py-2 font-medium bg-gray-50">Breakdown</th>
               </tr>

--- a/public/index.js
+++ b/public/index.js
@@ -735,13 +735,15 @@ async function loadLeaveReport() {
   const body = document.getElementById('leaveReportBody');
   if (!body) return;
   if (!data.length) {
-    body.innerHTML = '<tr><td colspan="3" class="px-4 py-2 italic text-gray-500">No leave records.</td></tr>';
+    body.innerHTML = '<tr><td colspan="5" class="px-4 py-2 italic text-gray-500">No leave records.</td></tr>';
     return;
   }
   body.innerHTML = data.map(r => {
     const breakdown = Object.entries(r.leaves).map(([k,v]) => `${capitalize(k)}: ${v}`).join(', ');
     return `<tr>
       <td class="px-4 py-2">${r.name}</td>
+      <td class="px-4 py-2">${r.title || ''}</td>
+      <td class="px-4 py-2">${r.location || ''}</td>
       <td class="px-4 py-2 text-center">${r.totalDays}</td>
       <td class="px-4 py-2">${breakdown}</td>
     </tr>`;
@@ -764,6 +766,8 @@ async function loadLeaveRange(start, end) {
     const breakdown = Object.entries(r.leaves).map(([k,v]) => `${capitalize(k)}: ${v}`).join(', ');
     return `<div class="bg-white border border-gray-200 rounded-lg shadow-sm p-4 w-64">
       <div class="font-semibold mb-1">${r.name}</div>
+      <div class="text-gray-700 mb-1"><b>Title:</b> ${r.title || ''}</div>
+      <div class="text-gray-700 mb-1"><b>Location:</b> ${r.location || ''}</div>
       <div class="mb-1 text-gray-700"><b>Total:</b> ${r.totalDays}</div>
       <div class="text-gray-700"><b>Breakdown:</b> ${breakdown}</div>
     </div>`;

--- a/server.js
+++ b/server.js
@@ -347,7 +347,14 @@ init().then(() => {
         totals[a.type] = (totals[a.type] || 0) + days;
         totalDays += days;
       });
-      return { id: emp.id, name: emp.name || '', totalDays, leaves: totals };
+      return {
+        id: emp.id,
+        name: emp.name || '',
+        title: emp.Title || emp.title || '',
+        location: emp['Country / City'] || emp.location || emp['country/city'] || '',
+        totalDays,
+        leaves: totals
+      };
     }).filter(r => r.totalDays > 0);
 
     report.sort((a, b) => b.totalDays - a.totalDays);


### PR DESCRIPTION
## Summary
- include employee title and location in server-side leave report data
- show title and location in leave report table and range cards

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689bf26082a0832e86503980092b0772