### PR TITLE
Fix leave report export with authenticated fetch

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -187,8 +187,22 @@ async function init() {
   }
   const exportBtn = document.getElementById('exportLeavesBtn');
   if (exportBtn) {
-    exportBtn.onclick = () => {
-      window.open(API + '/leave-report/export', '_blank');
+    exportBtn.onclick = async () => {
+      try {
+        const res = await apiFetch('/leave-report/export');
+        if (!res.ok) throw new Error('Export failed');
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'leave-report.csv';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+      } catch (e) {
+        alert('Failed to export leave report');
+      }
     };
   }
   const reportApply = document.getElementById('reportApply');


### PR DESCRIPTION
## Summary
- Ensure leave report export uses authenticated request and triggers CSV download

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c66824df4832ea76549c3d4fc3431