### PR TITLE
Improve leave calendar readability

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -984,11 +984,13 @@ async function loadLeaveCalendar() {
       classes.push('weekday');
     }
     if (future) classes.push('future');
-    const names = entries.map(e => e.name).join(', ');
-    const short = names.length > 25 ? names.substring(0,22) + '...' : names;
     let content = `<div class="calendar-date">${d}</div>`;
-    if (names) {
-      content += `<div class="calendar-names" title="${names}">${short}</div>`;
+    if (entries.length) {
+      const namesMarkup = entries.map(e => {
+        const typeLabel = capitalize(e.type);
+        return `<div class="calendar-name" title="${e.name} • ${typeLabel}">${e.name}</div>`;
+      }).join('');
+      content += `<div class="calendar-names">${namesMarkup}</div>`;
     }
     const title = entries.map(e => `${e.name} - ${capitalize(e.type)}`).join('\n');
     grid.innerHTML += `<div class="${classes.join(' ')}" title="${title}">${content}</div>`;

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -928,11 +928,24 @@ body {
 }
 
 .calendar-names {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: 100%;
   font-size: 0.75rem;
   color: rgba(71, 85, 105, 0.85);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  text-align: left;
+}
+
+.calendar-name {
+  width: 100%;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(99, 102, 241, 0.12);
+  color: rgba(30, 41, 59, 0.85);
+  line-height: 1.2;
+  word-break: break-word;
 }
 
 .range-actions {


### PR DESCRIPTION
## Summary
- render all leave entries in the calendar as individual name chips instead of truncating the list
- adjust calendar styles so names wrap vertically and remain readable within each day cell

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0ffe17324832e81facc6fbf9037a3