### PR TITLE
Implement global employee search in management tab

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -301,6 +301,15 @@
         </div>
 
         <div class="md-card" style="overflow-x:auto;">
+          <div class="table-toolbar">
+            <div class="md-field table-search">
+              <label class="md-label" for="empSearchInput">Search employees</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">search</span>
+                <input id="empSearchInput" type="text" class="md-input" placeholder="Search name, role, status, etc." autocomplete="off" spellcheck="false">
+              </div>
+            </div>
+          </div>
           <table id="empTable" class="data-table">
             <thead id="empTableHead"></thead>
             <tbody id="empTableBody"></tbody>

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -736,6 +736,19 @@ body {
   background: rgba(11, 87, 208, 0.06);
 }
 
+.table-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 320px;
+}
+
 .sticky-col {
   position: sticky;
   background: rgba(255, 255, 255, 0.98);
@@ -766,6 +779,13 @@ body {
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(248, 250, 255, 0.7);
   font-size: 0.85rem;
+}
+
+.table-empty {
+  text-align: center;
+  padding: 24px 16px;
+  color: var(--md-sys-color-subtle);
+  font-size: 0.95rem;
 }
 
 .status-pill {


### PR DESCRIPTION
## Summary
- replace the column filter row with a single search field above the employee table
- update management logic to search across all stored fields and persist the current query
- add styling for the new toolbar and empty-state message when no rows match

## Testing
- npm run start *(fails: requires a MongoDB instance for db.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d1016519c0832e8d5e2d115ebccbe2