### PR TITLE
Enhance leave calendar display

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -982,26 +982,43 @@ async function loadLeaveCalendar() {
     grid.innerHTML += '<div class="calendar-empty"></div>';
   }
   const today = new Date();
+  today.setHours(0,0,0,0);
   for (let d=1; d<=monthEnd.getDate(); d++) {
     const date   = new Date(monthStart.getFullYear(), monthStart.getMonth(), d);
+    const dayRef = new Date(date);
+    dayRef.setHours(0,0,0,0);
     const dateStr = date.toLocaleDateString('en-CA');
     const entries = map[dateStr] || [];
-    const future  = date > today;
+    const future  = dayRef > today;
+    const isToday = dayRef.getTime() === today.getTime();
     const classes = [];
     if ([1,2,3,4,5].includes(date.getDay())) {
       classes.push('weekday');
     }
     if (future) classes.push('future');
+    if (isToday) classes.push('calendar-today');
     let content = `<div class="calendar-date">${d}</div>`;
+    const titleParts = [];
     if (entries.length) {
       const namesMarkup = entries.map(e => {
-        const typeLabel = capitalize(e.type);
-        return `<div class="calendar-name" title="${e.name} • ${typeLabel}">${e.name}</div>`;
+        const rawType = (e.type || '').toString();
+        const typeLabel = capitalize(rawType);
+        const typeKey = rawType.replace(/[^a-z0-9]/gi, '').toLowerCase();
+        const typeClass = typeKey ? `calendar-type--${typeKey}` : '';
+        if (typeLabel) {
+          titleParts.push(`${e.name} - ${typeLabel}`);
+        } else {
+          titleParts.push(e.name);
+        }
+        const typeMarkup = typeLabel ? `<span class="calendar-type ${typeClass}">${typeLabel}</span>` : '';
+        const entryTitle = typeLabel ? `${e.name} • ${typeLabel}` : e.name;
+        return `<div class="calendar-name" title="${entryTitle}"><span class="calendar-employee">${e.name}</span>${typeMarkup}</div>`;
       }).join('');
       content += `<div class="calendar-names">${namesMarkup}</div>`;
     }
-    const title = entries.map(e => `${e.name} - ${capitalize(e.type)}`).join('\n');
-    grid.innerHTML += `<div class="${classes.join(' ')}" title="${title}">${content}</div>`;
+    const title = titleParts.join('\n');
+    const titleAttr = title ? ` title="${title}"` : '';
+    grid.innerHTML += `<div class="${classes.join(' ')}"${titleAttr}>${content}</div>`;
   }
 }
 

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -324,6 +324,27 @@ body {
   gap: 12px;
 }
 
+.app-actions #changePassBtn {
+  background: linear-gradient(135deg, #7c3aed, #4c1d95);
+  color: #fff;
+  border: none;
+  box-shadow: 0 14px 32px -18px rgba(79, 70, 229, 0.65);
+}
+
+.app-actions #changePassBtn:hover {
+  box-shadow: 0 18px 36px -18px rgba(79, 70, 229, 0.75);
+}
+
+.app-actions #logoutBtn {
+  background: rgba(254, 226, 226, 0.85);
+  border: 1px solid rgba(220, 38, 38, 0.4);
+  color: #b91c1c;
+}
+
+.app-actions #logoutBtn:hover {
+  background: rgba(254, 202, 202, 0.95);
+}
+
 .tab-bar {
   display: flex;
   gap: 12px;
@@ -933,8 +954,22 @@ body {
   color: rgba(71, 85, 105, 0.6);
 }
 
+.calendar-grid div.future .calendar-employee {
+  color: rgba(71, 85, 105, 0.7);
+}
+
+.calendar-grid div.future .calendar-type {
+  opacity: 0.75;
+}
+
 .calendar-grid div.weekday {
   background: rgba(219, 226, 255, 0.6);
+}
+
+.calendar-grid div.calendar-today {
+  background: rgba(191, 219, 254, 0.8);
+  border: 2px solid rgba(37, 99, 235, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.2);
 }
 
 .calendar-empty {
@@ -945,6 +980,7 @@ body {
 .calendar-date {
   font-weight: 700;
   font-size: 0.95rem;
+  color: #1d4ed8;
 }
 
 .calendar-names {
@@ -963,9 +999,65 @@ body {
   padding: 2px 6px;
   border-radius: 6px;
   background: rgba(99, 102, 241, 0.12);
-  color: rgba(30, 41, 59, 0.85);
   line-height: 1.2;
   word-break: break-word;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.calendar-employee {
+  color: rgba(30, 41, 59, 0.88);
+  font-weight: 600;
+}
+
+.calendar-type {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  background: rgba(59, 130, 246, 0.16);
+  color: #1d4ed8;
+}
+
+.calendar-type--annual {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.calendar-type--casual {
+  background: rgba(251, 191, 36, 0.22);
+  color: #b45309;
+}
+
+.calendar-type--medical {
+  background: rgba(134, 239, 172, 0.24);
+  color: #15803d;
+}
+
+.calendar-type--unpaid {
+  background: rgba(244, 114, 182, 0.2);
+  color: #be185d;
+}
+
+.calendar-type--maternity {
+  background: rgba(236, 72, 153, 0.18);
+  color: #be185d;
+}
+
+.calendar-type--paternity {
+  background: rgba(129, 140, 248, 0.22);
+  color: #4338ca;
+}
+
+.calendar-type--other {
+  background: rgba(203, 213, 225, 0.4);
+  color: #334155;
 }
 
 .range-actions {


### PR DESCRIPTION
## Summary
- show each leave entry with a colored type pill beside the employee name in the leave report calendar
- highlight the current day and distinguish calendar date styling from employee names for better readability
- restyle the header change-password and logout buttons with higher-contrast colors so they stand out on the background

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d104338318832eb66e43c4398bad0b