### PR TITLE
Improve calendar date styling for clarity

### DIFF
--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -980,7 +980,13 @@ body {
 .calendar-date {
   font-weight: 700;
   font-size: 0.95rem;
-  color: #1d4ed8;
+  color: #f8fafc;
+  background: #1d4ed8;
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 999px;
+  line-height: 1.2;
+  box-shadow: 0 6px 12px rgba(29, 78, 216, 0.12);
 }
 
 .calendar-names {


### PR DESCRIPTION
## Summary
- give the calendar date badge a darker background and white text to differentiate it from employee names

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1096beed8832eb8ac2ac719f8cc77