### PR TITLE
Revert calendar date styling

### DIFF
--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -980,13 +980,7 @@ body {
 .calendar-date {
   font-weight: 700;
   font-size: 0.95rem;
-  color: #f8fafc;
-  background: #1d4ed8;
-  align-self: flex-start;
-  padding: 4px 10px;
-  border-radius: 999px;
-  line-height: 1.2;
-  box-shadow: 0 6px 12px rgba(29, 78, 216, 0.12);
+  color: #1d4ed8;
 }
 
 .calendar-names {


### PR DESCRIPTION
## Summary
- restore the previous leave calendar date styling by removing the pill background treatment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d10aea55b8832e86794f29f8aa3c25