### PR TITLE
Add recruitment pipeline management

### DIFF
--- a/db.js
+++ b/db.js
@@ -18,25 +18,37 @@ const db = {
   data: null,
   async read() {
     await init();
-    const [employees, applications, users] = await Promise.all([
+    const [employees, applications, users, positions, candidates] = await Promise.all([
       database.collection('employees').find().toArray(),
       database.collection('applications').find().toArray(),
-      database.collection('users').find().toArray()
+      database.collection('users').find().toArray(),
+      database.collection('positions').find().toArray(),
+      database.collection('candidates').find().toArray()
     ]);
-    this.data = { employees, applications, users };
+    this.data = { employees, applications, users, positions, candidates };
   },
   async write() {
     if (!this.data) return;
     await init();
-    const { employees = [], applications = [], users = [] } = this.data;
+    const {
+      employees = [],
+      applications = [],
+      users = [],
+      positions = [],
+      candidates = []
+    } = this.data;
     await Promise.all([
       database.collection('employees').deleteMany({}),
       database.collection('applications').deleteMany({}),
-      database.collection('users').deleteMany({})
+      database.collection('users').deleteMany({}),
+      database.collection('positions').deleteMany({}),
+      database.collection('candidates').deleteMany({})
     ]);
     if (employees.length) await database.collection('employees').insertMany(employees);
     if (applications.length) await database.collection('applications').insertMany(applications);
     if (users.length) await database.collection('users').insertMany(users);
+    if (positions.length) await database.collection('positions').insertMany(positions);
+    if (candidates.length) await database.collection('candidates').insertMany(candidates);
   }
 };
 

--- a/public/index.html
+++ b/public/index.html
@@ -77,6 +77,10 @@
         <span class="material-symbols-rounded">group</span>
         <span>Employee Management</span>
       </button>
+      <button id="tabRecruitment" class="tab-button hidden">
+        <span class="material-symbols-rounded">work_history</span>
+        <span>Recruitment</span>
+      </button>
       <button id="tabManagerApps" class="tab-button hidden">
         <span class="material-symbols-rounded">inbox</span>
         <span>Leave Applications</span>
@@ -332,6 +336,125 @@
               </button>
               <button type="button" id="drawerCancelBtn" class="md-button md-button--outlined md-button--small">Cancel</button>
             </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Recruitment Pipeline Panel -->
+      <section id="recruitmentPanel" class="panel hidden">
+        <div class="panel-header">
+          <h2 class="panel-title">
+            <span class="material-symbols-rounded">work_history</span>
+            Recruitment Pipeline
+          </h2>
+          <p class="panel-subtitle">Open roles and monitor every candidate from first touch to hiring.</p>
+        </div>
+
+        <div class="card-grid">
+          <div class="md-card">
+            <div class="card-title">
+              <span class="material-symbols-rounded">playlist_add</span>
+              Create Position
+            </div>
+            <p class="card-subtitle">Document new openings so your hiring team stays aligned.</p>
+            <form id="positionForm" class="form-stack">
+              <div class="md-field">
+                <label class="md-label" for="positionTitle">Position title</label>
+                <div class="md-input-wrapper">
+                  <span class="material-symbols-rounded">badge</span>
+                  <input id="positionTitle" name="title" type="text" class="md-input" placeholder="e.g., Senior Designer" required>
+                </div>
+              </div>
+              <div class="md-field">
+                <label class="md-label" for="positionDepartment">Department</label>
+                <div class="md-input-wrapper">
+                  <span class="material-symbols-rounded">business_center</span>
+                  <input id="positionDepartment" name="department" type="text" class="md-input" placeholder="Optional">
+                </div>
+              </div>
+              <div class="md-field">
+                <label class="md-label" for="positionDescription">Description</label>
+                <textarea id="positionDescription" name="description" class="md-textarea" rows="3" placeholder="Add role highlights or notes"></textarea>
+              </div>
+              <button type="submit" class="md-button md-button--filled md-button--small">
+                <span class="material-symbols-rounded">save</span>
+                Save Position
+              </button>
+            </form>
+          </div>
+
+          <div class="md-card">
+            <div class="card-title">
+              <span class="material-symbols-rounded">view_list</span>
+              Open Positions
+            </div>
+            <div id="positionsList" class="positions-list">
+              <p class="text-muted" style="font-style: italic;">No positions yet. Add your first opening to start sourcing talent.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="card-grid">
+          <div class="md-card">
+            <div class="card-title">
+              <span class="material-symbols-rounded">person_add</span>
+              Add Candidate
+            </div>
+            <form id="candidateForm" class="form-grid">
+              <div class="md-field">
+                <label class="md-label" for="candidatePositionSelect">Position</label>
+                <div class="md-input-wrapper">
+                  <span class="material-symbols-rounded">work</span>
+                  <select id="candidatePositionSelect" name="positionId" class="md-select" required></select>
+                </div>
+              </div>
+              <div class="md-field">
+                <label class="md-label" for="candidateName">Candidate name</label>
+                <div class="md-input-wrapper">
+                  <span class="material-symbols-rounded">badge</span>
+                  <input id="candidateName" name="name" type="text" class="md-input" placeholder="Full name" required>
+                </div>
+              </div>
+              <div class="md-field">
+                <label class="md-label" for="candidateContact">Contact details</label>
+                <div class="md-input-wrapper">
+                  <span class="material-symbols-rounded">call</span>
+                  <input id="candidateContact" name="contact" type="text" class="md-input" placeholder="Email or phone" required>
+                </div>
+              </div>
+              <div class="md-field">
+                <label class="md-label" for="candidateCv">Upload CV</label>
+                <input id="candidateCv" name="cv" type="file" accept=".pdf,.doc,.docx,.docm,.rtf" required>
+                <p class="text-muted" style="margin-top:4px;">Accepted formats: PDF or Word documents.</p>
+              </div>
+              <button type="submit" class="md-button md-button--filled">
+                <span class="material-symbols-rounded">upload_file</span>
+                Add to Pipeline
+              </button>
+            </form>
+          </div>
+
+          <div class="md-card" style="overflow-x:auto;">
+            <div class="card-title">
+              <span class="material-symbols-rounded">timeline</span>
+              Candidate Pipeline
+            </div>
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Candidate</th>
+                  <th>Contact</th>
+                  <th>Status</th>
+                  <th>CV</th>
+                  <th>Created</th>
+                </tr>
+              </thead>
+              <tbody id="candidateTableBody">
+                <tr>
+                  <td colspan="5" class="text-muted" style="padding:16px; font-style: italic;">Select a position to view candidates.</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </section>

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -1083,6 +1083,82 @@ body {
   background: rgba(255, 255, 255, 0.8);
 }
 
+.positions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.position-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: var(--md-sys-color-surface, #ffffff);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  text-align: left;
+}
+
+.position-item:hover {
+  border-color: rgba(103, 80, 164, 0.4);
+  box-shadow: 0 6px 12px rgba(31, 31, 31, 0.08);
+}
+
+.position-item--active {
+  border-color: var(--md-sys-color-primary, #6750a4);
+  background: rgba(103, 80, 164, 0.1);
+  box-shadow: 0 8px 16px rgba(103, 80, 164, 0.2);
+}
+
+.position-item__icon {
+  font-size: 28px;
+  color: var(--md-sys-color-primary, #6750a4);
+}
+
+.position-item__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.position-item__title {
+  font-weight: 600;
+  font-size: 16px;
+  color: var(--md-sys-color-on-surface, #1c1b1f);
+}
+
+.position-item__meta {
+  font-size: 13px;
+  color: var(--md-sys-color-outline, #7a767f);
+}
+
+.position-item__description {
+  font-size: 13px;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.position-item__chevron {
+  color: var(--md-sys-color-outline, #7a767f);
+}
+
+.position-item--active .position-item__chevron,
+.position-item--active .position-item__icon {
+  color: var(--md-sys-color-primary, #6750a4);
+}
+
+.candidate-download {
+  margin-bottom: 4px;
+}
+
 @media (max-width: 900px) {
   .top-app-bar {
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- introduce a manager-only Recruitment tab with UI to create positions, add candidates, and track pipeline statuses
- persist recruitment positions and candidates through new database collections and REST endpoints, including CV download support
- style the recruitment overview components to match the existing material theme

## Testing
- npm start *(fails: missing optional dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1b5c0a44832eb3b45d64505075d4