### PR TITLE
Add interview completed status and manager candidate comments

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -445,19 +445,45 @@
                   <th>Candidate</th>
                   <th>Contact</th>
                   <th>Status</th>
+                  <th>Comments</th>
                   <th>CV</th>
                   <th>Created</th>
                 </tr>
               </thead>
               <tbody id="candidateTableBody">
                 <tr>
-                  <td colspan="5" class="text-muted" style="padding:16px; font-style: italic;">Select a position to view candidates.</td>
+                  <td colspan="6" class="text-muted" style="padding:16px; font-style: italic;">Select a position to view candidates.</td>
                 </tr>
               </tbody>
             </table>
           </div>
         </div>
       </section>
+
+      <div id="commentsModal" class="modal-backdrop hidden">
+        <div class="modal-card comments-modal">
+          <button type="button" id="commentsModalCloseBtn" class="modal-close material-symbols-rounded">close</button>
+          <h3 class="modal-title">
+            <span class="material-symbols-rounded">forum</span>
+            Candidate Comments
+          </h3>
+          <div class="comments-modal-header">
+            <div class="comments-modal-label">Candidate</div>
+            <div id="commentsModalCandidateName" class="comments-modal-name">-</div>
+          </div>
+          <div id="commentsList" class="comments-list text-muted">
+            <p style="font-style: italic;">Loading comments...</p>
+          </div>
+          <form id="commentForm" class="form-stack">
+            <label class="md-label" for="commentText">Add a comment</label>
+            <textarea id="commentText" class="md-textarea" rows="3" placeholder="Share feedback or interview notes" required></textarea>
+            <button id="commentSubmitBtn" type="submit" class="md-button md-button--filled md-button--small">
+              <span class="material-symbols-rounded">add_comment</span>
+              <span class="comment-submit-label">Add Comment</span>
+            </button>
+          </form>
+        </div>
+      </div>
 
       <!-- Manager Applications Panel -->
       <section id="managerAppsPanel" class="panel hidden">

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -601,6 +601,92 @@ body {
   gap: 12px;
 }
 
+.comments-modal {
+  width: min(560px, 100%);
+  max-height: 80vh;
+  overflow: hidden;
+}
+
+.comments-modal-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.comments-modal-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.comments-modal-name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.88);
+}
+
+.comments-list {
+  flex: 1;
+  min-height: 120px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.comment-item {
+  background: rgba(241, 245, 249, 0.8);
+  border-radius: 16px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.comment-item.own-comment {
+  border-color: rgba(59, 130, 246, 0.65);
+  background: rgba(239, 246, 255, 0.92);
+}
+
+.comment-item-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.comment-text {
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.9);
+  line-height: 1.4;
+}
+
+.comment-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.comment-edit {
+  font-size: 0.75rem;
+  color: var(--md-sys-color-primary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+}
+
+.comment-edit .material-symbols-rounded {
+  font-size: 16px;
+}
+
 #prevLeaves {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));


### PR DESCRIPTION
## Summary
- add the "Interview Completed" step to the recruitment pipeline on both the client and API
- allow managers to view, add, and edit candidate comments through a new modal UI with supporting endpoints
- style the modal and comment list for readability in the recruitment workflow

## Testing
- node --check server.js
- node --check public/index.js

------
https://chatgpt.com/codex/tasks/task_e_68de9bf768b4832ea3eade27f9bdc75f