### PR TITLE
Revamp candidate pipeline view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -445,20 +445,61 @@
                   <th>Candidate</th>
                   <th>Contact</th>
                   <th>Status</th>
-                  <th>Comments</th>
-                  <th>CV</th>
-                  <th>Created</th>
                 </tr>
               </thead>
               <tbody id="candidateTableBody">
                 <tr>
-                  <td colspan="6" class="text-muted" style="padding:16px; font-style: italic;">Select a position to view candidates.</td>
+                  <td colspan="3" class="text-muted" style="padding:16px; font-style: italic;">Select a position to view candidates.</td>
                 </tr>
               </tbody>
             </table>
           </div>
         </div>
       </section>
+
+      <div id="candidateDetailsModal" class="modal-backdrop hidden">
+        <div class="modal-card candidate-details-modal">
+          <button type="button" id="candidateDetailsCloseBtn" class="modal-close material-symbols-rounded">close</button>
+          <h3 class="modal-title">
+            <span class="material-symbols-rounded">person</span>
+            Candidate Details
+          </h3>
+          <div class="candidate-details-section">
+            <div class="candidate-details-label">Candidate</div>
+            <div id="candidateDetailsName" class="candidate-details-value">-</div>
+          </div>
+          <div class="candidate-details-section">
+            <div class="candidate-details-label">Contact</div>
+            <div id="candidateDetailsContact" class="candidate-details-value">-</div>
+          </div>
+          <div class="candidate-details-section">
+            <div class="candidate-details-label">Status</div>
+            <div id="candidateDetailsStatus" class="candidate-details-value">-</div>
+          </div>
+          <div class="candidate-details-section">
+            <div class="candidate-details-label">Created</div>
+            <div id="candidateDetailsCreated" class="candidate-details-value">-</div>
+          </div>
+          <div class="candidate-details-section">
+            <div class="candidate-details-label">Comments</div>
+            <div id="candidateDetailsComments" class="candidate-details-value">-</div>
+          </div>
+          <div class="candidate-details-section">
+            <div class="candidate-details-label">CV</div>
+            <div id="candidateDetailsCv" class="candidate-details-value">-</div>
+          </div>
+          <div class="candidate-details-actions">
+            <button type="button" id="candidateDetailsDownloadBtn" class="md-button md-button--tonal">
+              <span class="material-symbols-rounded">download</span>
+              Download CV
+            </button>
+            <button type="button" id="candidateDetailsCommentsBtn" class="md-button md-button--outlined">
+              <span class="material-symbols-rounded">forum</span>
+              View Comments
+            </button>
+          </div>
+        </div>
+      </div>
 
       <div id="commentsModal" class="modal-backdrop hidden">
         <div class="modal-card comments-modal">

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -626,6 +626,49 @@ body {
   color: rgba(15, 23, 42, 0.88);
 }
 
+.candidate-details-modal {
+  width: min(520px, 100%);
+}
+
+.candidate-details-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.candidate-details-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.candidate-details-value {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: rgba(15, 23, 42, 0.88);
+  word-break: break-word;
+}
+
+.candidate-details-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.candidate-name-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+.candidate-name {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.92);
+}
+
 .comments-list {
   flex: 1;
   min-height: 120px;


### PR DESCRIPTION
## Summary
- slim candidate pipeline table to only show candidate, contact, and status columns
- add a candidate details modal with CV download and comment shortcuts
- refresh recruitment scripts and styles to drive the modal and keep data in sync

## Testing
- npm start *(fails: requires a MongoDB instance and blocks startup)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa4c77d60832ea204cdf5375a3448