### PR TITLE
Add modal to capture employee details when hiring pipeline candidates

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -501,6 +501,29 @@
         </div>
       </div>
 
+      <div id="candidateHireModal" class="modal-backdrop hidden">
+        <div class="modal-card modal-card--wide">
+          <button type="button" id="candidateHireCloseBtn" class="modal-close material-symbols-rounded">close</button>
+          <h3 id="candidateHireTitle" class="modal-title">
+            <span class="material-symbols-rounded">badge</span>
+            <span id="candidateHireTitleText">Complete Employee Record</span>
+          </h3>
+          <p id="candidateHireSubtitle" class="text-muted" style="margin: -8px 0 4px;">
+            Provide the mandatory employee information before marking this candidate as hired.
+          </p>
+          <form id="candidateHireForm" class="form-grid modal-body-scroll">
+            <div id="candidateHireFields"></div>
+          </form>
+          <div class="modal-actions">
+            <button type="button" id="candidateHireCancelBtn" class="md-button md-button--text md-button--small">Cancel</button>
+            <button type="submit" form="candidateHireForm" class="md-button md-button--filled md-button--small">
+              <span class="material-symbols-rounded">save</span>
+              Save &amp; Mark Hired
+            </button>
+          </div>
+        </div>
+      </div>
+
       <div id="commentsModal" class="modal-backdrop hidden">
         <div class="modal-card comments-modal">
           <button type="button" id="commentsModalCloseBtn" class="modal-close material-symbols-rounded">close</button>

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -575,6 +575,21 @@ body {
   gap: 18px;
 }
 
+.modal-card--wide {
+  width: min(720px, 100%);
+  max-height: 85vh;
+}
+
+.modal-body-scroll {
+  overflow-y: auto;
+  max-height: 60vh;
+  padding-right: 4px;
+}
+
+#candidateHireFields {
+  display: contents;
+}
+
 .modal-close {
   position: absolute;
   top: 16px;


### PR DESCRIPTION
## Summary
- add a hiring confirmation modal that collects mandatory employee information before allowing a candidate to be marked as "Hired"
- reuse shared helpers to render dynamic employee fields and build employee payloads for both the drawer and the new hiring modal
- expand the candidate status change workflow to launch the modal and automatically create employee records once saved, along with supporting styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0add5f488832e84d624ef89d12498