### PR TITLE
Increase CV upload limit to 3mb

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,8 +9,8 @@ const { parse } = require('csv-parse/sync');
 
 const app = express();
 
-// Payload limit for incoming requests (default 1 MB)
-const BODY_LIMIT = process.env.BODY_LIMIT || '1mb';
+// Payload limit for incoming requests (default 3 MB to accommodate CV uploads)
+const BODY_LIMIT = process.env.BODY_LIMIT || '3mb';
 
 // Default admin credentials (can be overridden with env vars)
 const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@brillar.io';


### PR DESCRIPTION
## Summary
- raise the default request payload limit to 3 MB so CV uploads up to 3 MB are accepted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b23a5a88832ea2ea41a02d2f8784