### PR TITLE
Add CSV leave import workflow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -293,13 +293,18 @@
             <div class="list-card__actions" style="justify-content:flex-start;">
               <button id="csvUploadBtn" class="md-button md-button--outlined">
                 <span class="material-symbols-rounded">cloud_upload</span>
-                Upload CSV
+                Upload Employees CSV
+              </button>
+              <button id="leaveCsvUploadBtn" class="md-button md-button--outlined">
+                <span class="material-symbols-rounded">event_available</span>
+                Upload Leave CSV
               </button>
               <button id="addEmployeeBtn" class="md-button md-button--filled">
                 <span class="material-symbols-rounded">person_add</span>
                 Add Employee
               </button>
               <input id="csvInput" type="file" accept=".csv" class="hidden">
+              <input id="leaveCsvInput" type="file" accept=".csv" class="hidden">
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a protected `/applications/bulk-import` endpoint that validates CSV rows, links them to employees, and records approved leave without touching balances
- surface a "Upload Leave CSV" action in the manager quick actions card and wire it to the new API with user feedback and data refreshes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0edffef1c832ea800ab381b616005