### PR TITLE
Add holiday management settings and exclude holidays from leave deductions

### DIFF
--- a/db.js
+++ b/db.js
@@ -18,14 +18,15 @@ const db = {
   data: null,
   async read() {
     await init();
-    const [employees, applications, users, positions, candidates] = await Promise.all([
+    const [employees, applications, users, positions, candidates, holidays] = await Promise.all([
       database.collection('employees').find().toArray(),
       database.collection('applications').find().toArray(),
       database.collection('users').find().toArray(),
       database.collection('positions').find().toArray(),
-      database.collection('candidates').find().toArray()
+      database.collection('candidates').find().toArray(),
+      database.collection('holidays').find().toArray()
     ]);
-    this.data = { employees, applications, users, positions, candidates };
+    this.data = { employees, applications, users, positions, candidates, holidays };
   },
   async write() {
     if (!this.data) return;
@@ -35,20 +36,23 @@ const db = {
       applications = [],
       users = [],
       positions = [],
-      candidates = []
+      candidates = [],
+      holidays = []
     } = this.data;
     await Promise.all([
       database.collection('employees').deleteMany({}),
       database.collection('applications').deleteMany({}),
       database.collection('users').deleteMany({}),
       database.collection('positions').deleteMany({}),
-      database.collection('candidates').deleteMany({})
+      database.collection('candidates').deleteMany({}),
+      database.collection('holidays').deleteMany({})
     ]);
     if (employees.length) await database.collection('employees').insertMany(employees);
     if (applications.length) await database.collection('applications').insertMany(applications);
     if (users.length) await database.collection('users').insertMany(users);
     if (positions.length) await database.collection('positions').insertMany(positions);
     if (candidates.length) await database.collection('candidates').insertMany(candidates);
+    if (holidays.length) await database.collection('holidays').insertMany(holidays);
   }
 };
 

--- a/public/index.html
+++ b/public/index.html
@@ -89,6 +89,10 @@
         <span class="material-symbols-rounded">insights</span>
         <span>Leave Report</span>
       </button>
+      <button id="tabSettings" class="tab-button hidden">
+        <span class="material-symbols-rounded">settings</span>
+        <span>Settings</span>
+      </button>
     </nav>
 
     <main class="content-area">
@@ -657,6 +661,46 @@
         </div>
 
         <div id="leaveRangeCards"></div>
+      </section>
+
+      <!-- Settings Panel -->
+      <section id="settingsPanel" class="panel hidden">
+        <div class="panel-header">
+          <h2 class="panel-title">
+            <span class="material-symbols-rounded">settings</span>
+            Settings
+          </h2>
+          <p class="panel-subtitle">Configure company holidays to ensure accurate leave balances.</p>
+        </div>
+
+        <div class="md-card">
+          <div class="card-title">
+            <span class="material-symbols-rounded">calendar_month</span>
+            Holiday Calendar
+          </div>
+          <p class="card-subtitle">Add official days off so applied leaves on these dates won't deduct balances.</p>
+          <form id="holidayForm" class="settings-form">
+            <div class="settings-form__fields">
+              <label class="md-label" for="holidayDate">Holiday date</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">event</span>
+                <input type="date" id="holidayDate" class="md-input" required>
+              </div>
+            </div>
+            <div class="settings-form__fields">
+              <label class="md-label" for="holidayName">Holiday name</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">celebration</span>
+                <input type="text" id="holidayName" class="md-input" placeholder="e.g., Founders' Day" required>
+              </div>
+            </div>
+            <button type="submit" class="md-button md-button--filled md-button--small settings-form__submit">
+              <span class="material-symbols-rounded">add</span>
+              Add Holiday
+            </button>
+          </form>
+          <div id="holidayList" class="holiday-list"></div>
+        </div>
       </section>
     </main>
   </div>

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -1211,6 +1211,74 @@ body {
   align-items: flex-end;
 }
 
+.settings-form {
+  margin-top: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+}
+
+.settings-form__fields {
+  flex: 1 1 220px;
+  min-width: 200px;
+}
+
+.settings-form__submit {
+  align-self: flex-end;
+}
+
+.holiday-list {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.holiday-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  border-radius: 18px;
+  background: rgba(11, 87, 208, 0.08);
+  border: 1px solid rgba(11, 87, 208, 0.15);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  flex-wrap: wrap;
+}
+
+.holiday-item__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 200px;
+}
+
+.holiday-item__date {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--md-sys-color-primary);
+}
+
+.holiday-item__name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--md-sys-color-text);
+}
+
+.holiday-item__iso {
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.holiday-item__delete {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+
 .range-actions label {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a manager-only Settings tab with a holiday management form and supporting styles
- store holidays in the database, expose CRUD endpoints, and wire the portal to load/add/remove holidays
- skip company holidays when calculating leave deductions and balances

## Testing
- node --check server.js
- node --check public/index.js

------
https://chatgpt.com/codex/tasks/task_e_68e0f7a79b60832e8bd48ca5efaf64a6