### PR TITLE
Fix manager role detection for holiday management

### DIFF
--- a/server.js
+++ b/server.js
@@ -60,7 +60,7 @@ function getEmpEmail(emp) {
 function getEmpRole(emp) {
   if (!emp) return 'employee';
   const key = Object.keys(emp).find(k => k.toLowerCase() === 'role');
-  const value = key ? String(emp[key] || '').toLowerCase() : '';
+  const value = key ? String(emp[key] || '').trim().toLowerCase() : '';
   return value === 'manager' ? 'manager' : 'employee';
 }
 


### PR DESCRIPTION
## Summary
- trim stored employee roles before deriving permissions so managers keep access to holiday management even with trailing whitespace

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1ffac58b8832eaf97857ab9098a54