### PR TITLE
Add employee self-service profile tab

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -69,6 +69,10 @@
     </header>
 
     <nav class="tab-bar">
+      <button id="tabProfile" class="tab-button hidden">
+        <span class="material-symbols-rounded">account_circle</span>
+        <span>My Profile</span>
+      </button>
       <button id="tabPortal" class="tab-button active-tab">
         <span class="material-symbols-rounded">event_available</span>
         <span>Leave Portal</span>
@@ -96,6 +100,94 @@
     </nav>
 
     <main class="content-area">
+      <!-- Employee Profile Panel -->
+      <section id="profilePanel" class="panel hidden">
+        <div class="panel-header">
+          <h2 class="panel-title">
+            <span class="material-symbols-rounded">account_circle</span>
+            My Profile
+          </h2>
+          <p class="panel-subtitle">Review your personal information, update contact details, and keep emergency information accurate.</p>
+        </div>
+
+        <div class="card-grid profile-summary-grid">
+          <div class="md-card">
+            <div class="card-title">
+              <span class="material-symbols-rounded">badge</span>
+              Profile Overview
+            </div>
+            <dl class="profile-summary-list">
+              <div class="profile-summary-item">
+                <dt>Name</dt>
+                <dd id="profileSummaryName">-</dd>
+              </div>
+              <div class="profile-summary-item">
+                <dt>Work Email</dt>
+                <dd id="profileSummaryEmail">-</dd>
+              </div>
+              <div class="profile-summary-item">
+                <dt>Title</dt>
+                <dd id="profileSummaryTitle">-</dd>
+              </div>
+              <div class="profile-summary-item">
+                <dt>Department</dt>
+                <dd id="profileSummaryDepartment">-</dd>
+              </div>
+              <div class="profile-summary-item">
+                <dt>Reporting Manager</dt>
+                <dd id="profileSummaryManager">-</dd>
+              </div>
+              <div class="profile-summary-item">
+                <dt>Status</dt>
+                <dd id="profileSummaryStatus">-</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div class="md-card">
+            <div class="card-title">
+              <span class="material-symbols-rounded">account_balance_wallet</span>
+              Leave Balances
+            </div>
+            <div id="profileLeaveBalances" class="balance-chips profile-balance-chips">
+              <div class="balance-chip chip-annual">
+                <span class="material-symbols-rounded">beach_access</span>
+                <div>
+                  <span class="label">Annual</span>
+                  <strong id="profileBalAnnual">-</strong><span class="unit">days</span>
+                </div>
+              </div>
+              <div class="balance-chip chip-casual">
+                <span class="material-symbols-rounded">sunny</span>
+                <div>
+                  <span class="label">Casual</span>
+                  <strong id="profileBalCasual">-</strong><span class="unit">days</span>
+                </div>
+              </div>
+              <div class="balance-chip chip-medical">
+                <span class="material-symbols-rounded">medical_information</span>
+                <div>
+                  <span class="label">Medical</span>
+                  <strong id="profileBalMedical">-</strong><span class="unit">days</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div id="profileGlobalFeedback" class="profile-feedback hidden"></div>
+
+        <div id="profileSections" class="profile-section-grid">
+          <div class="md-card">
+            <div class="card-title">
+              <span class="material-symbols-rounded">info</span>
+              Profile Details
+            </div>
+            <p class="text-muted" style="font-style: italic;">Loading profile information...</p>
+          </div>
+        </div>
+      </section>
+
       <!-- Leave Portal Panel -->
       <section id="portalPanel" class="panel">
         <div class="panel-header">

--- a/public/styles.css
+++ b/public/styles.css
@@ -39,3 +39,106 @@
 .no-col        { width: 56px; min-width: 56px; max-width: 56px; left: 0; z-index: 30; }
 .name-col      { width: 180px; min-width: 180px; max-width: 180px; left: 56px; z-index: 20; }
 .actions-col   { right: 0; z-index: 10; }
+
+.profile-summary-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  margin-bottom: 24px;
+}
+
+.profile-summary-list {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.profile-summary-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.profile-summary-item dt {
+  font-weight: 600;
+  color: #475569;
+}
+
+.profile-summary-item dd {
+  margin: 0;
+  text-align: right;
+  font-weight: 500;
+  color: #111827;
+}
+
+.profile-section-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.profile-section-form .md-field {
+  margin-bottom: 16px;
+}
+
+.profile-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.profile-field {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 8px 0;
+  border-bottom: 1px solid #e2e8f0;
+  gap: 16px;
+}
+
+.profile-field:last-child {
+  border-bottom: none;
+}
+
+.profile-field__label {
+  font-weight: 600;
+  color: #475569;
+}
+
+.profile-field__value {
+  text-align: right;
+  color: #111827;
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.profile-field__value--empty {
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.profile-feedback {
+  margin: 8px 0 0;
+  font-size: 0.9rem;
+  color: #0f7b32;
+}
+
+.profile-feedback.error {
+  color: #b3261e;
+}
+
+.profile-feedback.hidden {
+  display: none;
+}
+
+.profile-balance-chips .balance-chip {
+  flex: 1;
+  min-width: 0;
+}
+
+.profile-section-form .profile-field {
+  border-bottom: none;
+  padding: 0;
+  margin-bottom: 12px;
+}


### PR DESCRIPTION
## Summary
- add a dedicated My Profile tab with overview and editable sections for employees
- create new profile styling and client logic to load and update contact, personal, and emergency information
- introduce backend profile helpers plus GET/PUT endpoints so employees can review and update their own records

## Testing
- npm run start *(fails: MongoDB connection refused in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2aa53f8fc832e9259ae84fc0e91fd