### PR TITLE
Refine profile UI alignment and read-only styling

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -270,13 +270,17 @@ function renderProfileSection(section) {
         </div>
       `;
     }
+    const inputId = makeDynamicFieldId('profile', `${key}-readonly`);
     const hasValue = value && value.trim() !== '';
-    const valueClass = hasValue ? 'profile-field__value' : 'profile-field__value profile-field__value--empty';
     const displayValue = hasValue ? escapeHtml(value) : 'Not provided';
+    const valueAttr = ` value="${displayValue}"`;
+    const emptyClass = hasValue ? '' : ' md-input--empty';
     return `
-      <div class="profile-field">
-        <span class="profile-field__label">${label}</span>
-        <span class="${valueClass}">${displayValue}</span>
+      <div class="md-field md-field--readonly">
+        <label class="md-label" for="${escapeHtml(inputId)}">${label}</label>
+        <div class="md-input-wrapper md-input-wrapper--readonly">
+          <input class="md-input${emptyClass}" id="${escapeHtml(inputId)}" type="text"${valueAttr} disabled>
+        </div>
       </div>
     `;
   }).join('');

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -143,6 +143,33 @@ body {
   color: var(--md-sys-color-primary);
 }
 
+.md-field--readonly .md-label {
+  color: #1e293b;
+}
+
+.md-input-wrapper--readonly {
+  background: rgba(241, 245, 249, 0.95);
+  border-color: rgba(148, 163, 184, 0.45);
+  box-shadow: none;
+}
+
+.md-field--readonly .md-input {
+  font-weight: 500;
+  cursor: default;
+}
+
+.md-field--readonly .md-input:disabled {
+  color: #0f172a;
+  -webkit-text-fill-color: #0f172a;
+  opacity: 1;
+}
+
+.md-field--readonly .md-input--empty:disabled {
+  color: #94a3b8;
+  -webkit-text-fill-color: #94a3b8;
+  font-style: italic;
+}
+
 .md-input,
 .md-select,
 .md-textarea {

--- a/public/styles.css
+++ b/public/styles.css
@@ -75,47 +75,27 @@
 
 .profile-section-grid {
   display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  align-items: stretch;
+}
+
+.profile-section-grid .md-card {
+  height: 100%;
+}
+
+.profile-section-form {
   gap: 20px;
 }
 
 .profile-section-form .md-field {
-  margin-bottom: 16px;
+  margin-bottom: 0;
 }
 
 .profile-form-actions {
   display: flex;
   justify-content: flex-end;
-  margin-top: 8px;
-}
-
-.profile-field {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  padding: 8px 0;
-  border-bottom: 1px solid #e2e8f0;
-  gap: 16px;
-}
-
-.profile-field:last-child {
-  border-bottom: none;
-}
-
-.profile-field__label {
-  font-weight: 600;
-  color: #475569;
-}
-
-.profile-field__value {
-  text-align: right;
-  color: #111827;
-  font-weight: 500;
-  word-break: break-word;
-}
-
-.profile-field__value--empty {
-  color: #94a3b8;
-  font-style: italic;
+  margin-top: 4px;
 }
 
 .profile-feedback {
@@ -137,8 +117,3 @@
   min-width: 0;
 }
 
-.profile-section-form .profile-field {
-  border-bottom: none;
-  padding: 0;
-  margin-bottom: 12px;
-}


### PR DESCRIPTION
## Summary
- render profile section read-only values with disabled inputs for a consistent layout
- tune the profile section grid spacing so cards align cleanly
- add read-only input styles to the material theme for better contrast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3357e1bd0832e8051293c34e4987b