### PR TITLE
Handle CORS preflight wildcard parsing error

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,7 +49,7 @@ app.use((req, res, next) => {
     next();
   });
 });
-app.options('*', corsMiddleware);
+app.options(/.*/, corsMiddleware);
 
 // Default leave balance values assigned to new employees
 const DEFAULT_LEAVE_BALANCES = { annual: 10, casual: 5, medical: 14 };


### PR DESCRIPTION
## Summary
- replace the Express `app.options('*', ...)` handler with a regular expression so it works with the newer path-to-regexp parser

## Testing
- `npm test` *(fails: Missing script "test" defined in package.json)*
- `node server.js` *(fails: Cannot find module 'cors')*

------
https://chatgpt.com/codex/tasks/task_e_68e35ab1370c832eace27ecf4270fcbc