### PR TITLE
Fix wildcard OPTIONS handler for Express 5

### DIFF
--- a/server.js
+++ b/server.js
@@ -46,7 +46,11 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
-app.options('*', cors(corsOptions));
+app.options(
+  '/:path(*)',
+  cors(corsOptions),
+  (req, res) => res.sendStatus(204)
+);
 
 // Default leave balance values assigned to new employees
 const DEFAULT_LEAVE_BALANCES = { annual: 10, casual: 5, medical: 14 };


### PR DESCRIPTION
## Summary
- replace the deprecated Express 4 style wildcard OPTIONS route with an Express 5 compatible pattern
- ensure preflight requests return 204 responses after applying configured CORS middleware

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e3791cae00832e912251e28180e4a0