### PR TITLE
Fix CORS preflight route for Express 5 compatibility

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ const corsOptions = {
 
 app.use(cors(corsOptions));
 app.options(
-  '/:path(*)',
+  '*',
   cors(corsOptions),
   (req, res) => res.sendStatus(204)
 );


### PR DESCRIPTION
## Summary
- replace the deprecated Express route pattern used for CORS preflight handling with a wildcard route compatible with path-to-regexp v6

## Testing
- not run (requires external services or environment configuration)

------
https://chatgpt.com/codex/tasks/task_e_68e37c0747d0832ead908def16709c44