### PR TITLE
Fix CORS preflight route for path-to-regexp compatibility

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ const corsOptions = {
 
 app.use(cors(corsOptions));
 app.options(
-  '*',
+  /.*/,
   cors(corsOptions),
   (req, res) => res.sendStatus(204)
 );


### PR DESCRIPTION
## Summary
- replace the wildcard OPTIONS handler string with a regular expression so Express no longer throws a path-to-regexp "Missing parameter name" error
- continue to respond to preflight requests with the configured CORS handler and 204 status

## Testing
- node server.js *(fails: Cannot find module 'cors')*


------
https://chatgpt.com/codex/tasks/task_e_68e37e7fab10832e92c8adb04bbb027e