### PR TITLE
Add ability to enable/disable chat widget from Settings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6929,8 +6929,12 @@
             <span class="material-symbols-rounded">forum</span>
             Chat Widget
           </div>
-          <p class="card-subtitle">Update the embedded chat widget URL used in the portal.</p>
+          <p class="card-subtitle">Enable or disable the embedded chat widget and update its URL.</p>
           <form id="chatWidgetSettingsForm" class="settings-form">
+            <div class="settings-form__toggle">
+              <input type="checkbox" id="chatWidgetEnabled" checked>
+              <label for="chatWidgetEnabled" class="md-label">Enable chat widget</label>
+            </div>
             <div class="settings-form__fields settings-form__fields--full">
               <label class="md-label" for="chatWidgetUrl">Widget URL</label>
               <div class="md-input-wrapper">


### PR DESCRIPTION
### Motivation
- Provide a settings toggle so managers can disable the embedded chat widget and remove it from all pages without deleting its configuration.
- Persist an `enabled` flag server-side so the UI and pages can consistently respect the widget state.

### Description
- Added an `enabled` boolean to the chat widget settings returned by `GET /settings/widget` and accepted by `PUT /settings/widget`, defaulting to `true` when unset and validated on save.
- Updated server persistence to store `{ url, enabled }` and to validate `enabled` is a boolean when present.
- Added a checkbox toggle to the Settings → Chat Widget form (`public/index.html`) and wired it into the settings form rendering and submit flow so the `enabled` flag is included when saving.
- Implemented front-end logic (`isChatWidgetEnabled`, `syncChatWidgetVisibility`) to hide the iframe and reset its `src` to `about:blank` when disabled, and to skip injecting the widget URL/user when disabled.

### Testing
- Ran static checks `node --check server.js` and `node --check public/index.js`, both succeeded.
- Ran automated tests with `npm test -- --test-reporter=spec`, which executed the suite of 9 tests and all passed (9 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69956583b7a08332af8fd80f9f741649)