### PR TITLE
Fix undefined fit value in AI screening UI

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -8360,8 +8360,14 @@ function renderAiCvScreening(application) {
 
   if (!fitLevelEl || !fitScoreEl || !summaryEl || !strengthsUl || !concernsUl || !rec) return;
 
-  fitLevelEl.innerText = r.fitLevel;
-  fitScoreEl.innerText = r.fitScore != null ? r.fitScore.toFixed(1) : '';
+  const fitLevel =
+    (typeof r.fitLevel === 'string' && r.fitLevel.trim()) ||
+    (typeof r.recommendation === 'string' && r.recommendation.trim()) ||
+    '-';
+  const fitScore = Number.isFinite(Number(r.fitScore)) ? Number(r.fitScore).toFixed(1) : '';
+
+  fitLevelEl.innerText = fitLevel;
+  fitScoreEl.innerText = fitScore;
 
   summaryEl.innerText = r.summary || '';
 
@@ -8373,13 +8379,14 @@ function renderAiCvScreening(application) {
   });
 
   concernsUl.innerHTML = '';
-  (r.concerns || []).forEach(c => {
+  const concerns = Array.isArray(r.concerns) ? r.concerns : (Array.isArray(r.risks) ? r.risks : []);
+  concerns.forEach(c => {
     const li = document.createElement('li');
     li.innerText = c;
     concernsUl.appendChild(li);
   });
 
-  rec.innerText = r.recommendation;
+  rec.innerText = typeof r.recommendation === 'string' ? r.recommendation : '';
   rec.classList.remove('bg-green-600', 'bg-yellow-600', 'bg-red-600');
   rec.classList.add(
     r.recommendation === 'proceed_to_ai_interview' ? 'bg-green-600' :


### PR DESCRIPTION
### Motivation
- The AI CV screening panel could display `Fit: undefined` because it used `r.fitLevel` directly while some model responses omit `fitLevel` or use alternate fields like `recommendation` or `risks`, so the UI needs robust fallbacks and safer formatting.

### Description
- Update `public/index.js` to compute a `fitLevel` fallback using `fitLevel` → `recommendation` → `-` so the label never shows `undefined`.
- Normalize `fitScore` rendering to only format finite numeric values using `Number.isFinite(Number(r.fitScore))` and `toFixed(1)`.
- Support both `concerns` and `risks` by deriving `const concerns = Array.isArray(r.concerns) ? r.concerns : (Array.isArray(r.risks) ? r.risks : [])` before rendering.
- Ensure recommendation text is only assigned when it is a string with `rec.innerText = typeof r.recommendation === 'string' ? r.recommendation : ''` to avoid showing `undefined`.

### Testing
- Ran automated test suite with `npm test --silent` and all tests passed (`9` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69957990bcd08332b79bbc8548e6dd56)