### PR TITLE
Fix Candidate 365 modal default scroll position and remove excess blank scroll space

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -8528,7 +8528,14 @@ function openCandidateDetailsModal(candidateId) {
   loadCandidateComments(candidate.id);
   loadCandidateCvPreview(candidate);
   const modal = document.getElementById('candidateDetailsModal');
-  if (modal) modal.classList.remove('hidden');
+  const modalCard = modal ? modal.querySelector('.candidate-details-modal') : null;
+  if (modal) {
+    modal.classList.remove('hidden');
+    modal.scrollTop = 0;
+  }
+  if (modalCard) modalCard.scrollTop = 0;
+  const commentsList = document.getElementById('commentsList');
+  if (commentsList) commentsList.scrollTop = 0;
   const textarea = document.getElementById('commentText');
   if (textarea) textarea.focus();
 }

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -1638,9 +1638,10 @@ body {
 }
 
 #candidateDetailsModal {
-  align-items: stretch;
-  justify-content: stretch;
-  padding: 0;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 24px;
+  overflow-y: auto;
 }
 
 .employee-modal__fields {
@@ -1791,10 +1792,10 @@ body {
 
 .candidate-details-modal {
   width: 100%;
-  max-width: none;
-  height: 100%;
-  max-height: none;
-  border-radius: 0;
+  max-width: 1200px;
+  height: auto;
+  max-height: calc(100vh - 48px);
+  border-radius: 24px;
   padding: clamp(24px, 4vw, 40px);
   box-sizing: border-box;
   overflow-y: auto;
@@ -1963,8 +1964,13 @@ body {
 }
 
 @media (max-width: 900px) {
+  #candidateDetailsModal {
+    padding: 16px;
+  }
+
   .candidate-details-modal {
     padding: 24px 16px;
+    max-height: calc(100vh - 32px);
   }
 
   .candidate-details-grid {


### PR DESCRIPTION
### Motivation
- The Candidate 365 details modal was opening at a previous scrolled position and left large blank/scrollable whitespace below the content, allowing scrolling into empty area.
- The page should present candidate details wrapped immediately after the Team Comments and AI CV Screening sections and always open scrolled to the top.

### Description
- Reset scroll positions when opening the modal by setting `modal.scrollTop = 0`, `modalCard.scrollTop = 0` and `commentsList.scrollTop = 0` in `openCandidateDetailsModal` (`public/index.js`).
- Update `#candidateDetailsModal` styles to use `align-items: flex-start`, centered justification, added padding and `overflow-y: auto` to avoid forcing full-screen stretch (`public/material-theme.css`).
- Constrain `.candidate-details-modal` with `max-width: 1200px`, `height: auto`, `max-height: calc(100vh - 48px)`, and rounded corners so the modal only scrolls internally when content actually overflows (`public/material-theme.css`).
- Add responsive adjustments for small screens to reduce modal padding and cap `max-height` to prevent extra whitespace scrolling on mobile (`public/material-theme.css`).

### Testing
- Ran unit tests with `node --test`, which completed successfully (9 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69957bbe674c8332b04cad40bc764535)