### PR TITLE
Fix transparent sticky columns overlap in Employee Management grid

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4366,7 +4366,19 @@
 .data-grid-table .sticky-actions {
   position: sticky;
   z-index: 5;
-  background: inherit;
+  background: #ffffff;
+}
+
+.data-grid-table thead .sticky-name,
+.data-grid-table thead .sticky-status,
+.data-grid-table thead .sticky-actions {
+  background: #f8fafc;
+}
+
+.data-grid-table tbody tr:hover .sticky-name,
+.data-grid-table tbody tr:hover .sticky-status,
+.data-grid-table tbody tr:hover .sticky-actions {
+  background: #f8fafc;
 }
 
 .data-grid-table .sticky-name { left: 0; z-index: 7; }

--- a/public/styles.css
+++ b/public/styles.css
@@ -2092,7 +2092,19 @@
 .data-grid-table .sticky-actions {
   position: sticky;
   z-index: 5;
-  background: inherit;
+  background: #ffffff;
+}
+
+.data-grid-table thead .sticky-name,
+.data-grid-table thead .sticky-status,
+.data-grid-table thead .sticky-actions {
+  background: #f8fafc;
+}
+
+.data-grid-table tbody tr:hover .sticky-name,
+.data-grid-table tbody tr:hover .sticky-status,
+.data-grid-table tbody tr:hover .sticky-actions {
+  background: #f8fafc;
 }
 
 .data-grid-table .sticky-name { left: 0; z-index: 7; }


### PR DESCRIPTION
### Motivation
- The sticky columns in the Employee Management data grid (`Name`, `Status`, `Actions`) were using inherited/translucent backgrounds and were visually overlapping scrolling content, making rows hard to read.
- The change ensures frozen columns have an explicit opaque background so they remain visually separate from the scrolling table content.

### Description
- Set explicit opaque background for sticky columns by changing their CSS to `background: #ffffff` in `public/styles.css` and the embedded stylesheet in `public/index.html`.
- Added header-specific rules (`.data-grid-table thead .sticky-*`) to preserve the header background as `#f8fafc` for visual consistency.
- Added hover-specific rules (`.data-grid-table tbody tr:hover .sticky-*`) to keep sticky cells matching hovered row background when hovering, preventing mismatch artifacts while scrolling.
- Applied the same fixes to both the main stylesheet and the duplicated embedded style block so behavior is consistent across loading contexts.

### Testing
- Ran the test suite with `npm test --silent` and all automated tests passed (`9` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699583d4697c83328d9d79f41deaff97)