### PR TITLE
Add Career Page builder in Settings with preview and persistence

### DIFF
--- a/public/careers.html
+++ b/public/careers.html
@@ -32,7 +32,7 @@
   </header>
 
   <main>
-    <section class="bg-gradient-to-r from-blue-900 via-blue-700 to-blue-500 text-white">
+    <section id="careerCustomHeader" class="bg-gradient-to-r from-blue-900 via-blue-700 to-blue-500 text-white">
       <div class="max-w-5xl mx-auto px-6 py-16">
         <p class="text-sm uppercase tracking-widest text-blue-100">Brillar Careers</p>
         <h1 class="text-4xl sm:text-5xl font-bold mt-4">Your Digital Transformation Partner</h1>
@@ -44,7 +44,7 @@
       </div>
     </section>
 
-    <section class="max-w-5xl mx-auto px-6 -mt-10">
+    <section id="careerCustomUpdates" class="max-w-5xl mx-auto px-6 -mt-10">
       <div class="bg-white rounded-2xl shadow-lg p-6 sm:p-8">
         <h3 class="text-2xl font-semibold text-gray-900">Careers at Brillar</h3>
         <p class="mt-3 text-gray-600">At Brillar, we are passionate about empowering organizations through technology. Join a team that values innovation, collaboration, and making a meaningful impact for our partners across the region.</p>
@@ -61,7 +61,7 @@
       </div>
     </section>
 
-    <section class="max-w-5xl mx-auto px-6 pb-16">
+    <section id="careerCustomContent" class="max-w-5xl mx-auto px-6 pb-16">
       <div id="job-detail" class="bg-white rounded-xl shadow p-6 sm:p-8">
         <h3 class="text-xl font-semibold text-gray-900">Explore our openings</h3>
         <p class="text-gray-600 mt-2">Select a role to view details and apply.</p>
@@ -69,7 +69,7 @@
     </section>
   </main>
 
-  <footer class="bg-gray-900 text-gray-300 text-sm py-6 mt-10">
+  <footer id="careerCustomFooter" class="bg-gray-900 text-gray-300 text-sm py-6 mt-10">
     <div class="max-w-5xl mx-auto px-6 text-center space-y-1">
       <p>© Brillar. All rights reserved.</p>
     </div>

--- a/public/careers.js
+++ b/public/careers.js
@@ -3,6 +3,11 @@ const jobDetailEl = document.getElementById('job-detail');
 const careersBrandLogoEl = document.getElementById('careersBrandLogo');
 const DEFAULT_ORGANIZATION_LOGO_URL = '/logo.png';
 
+const careerCustomHeaderEl = document.getElementById('careerCustomHeader');
+const careerCustomUpdatesEl = document.getElementById('careerCustomUpdates');
+const careerCustomContentEl = document.getElementById('careerCustomContent');
+const careerCustomFooterEl = document.getElementById('careerCustomFooter');
+
 async function fetchJson(url, options = {}) {
   const res = await fetch(url, options);
   if (!res.ok) {
@@ -24,6 +29,26 @@ async function loadOrganizationBranding() {
     careersBrandLogoEl.src = logoUrl;
   } catch (_error) {
     careersBrandLogoEl.src = DEFAULT_ORGANIZATION_LOGO_URL;
+  }
+}
+
+
+function applyCustomCareerSection(element, html) {
+  if (!element || typeof html !== 'string') return;
+  const trimmed = html.trim();
+  if (!trimmed) return;
+  element.innerHTML = trimmed;
+}
+
+async function loadCareerPageBuilderSettings() {
+  try {
+    const settings = await fetchJson('/public/settings/career-page');
+    applyCustomCareerSection(careerCustomHeaderEl, settings?.header);
+    applyCustomCareerSection(careerCustomUpdatesEl, settings?.updates);
+    applyCustomCareerSection(careerCustomContentEl, settings?.content);
+    applyCustomCareerSection(careerCustomFooterEl, settings?.footer);
+  } catch (_error) {
+    // Keep default careers layout when custom builder settings are unavailable.
   }
 }
 
@@ -192,4 +217,5 @@ if (openPositionsButton) {
 }
 
 loadOrganizationBranding();
+loadCareerPageBuilderSettings();
 loadPositions();

--- a/public/index.html
+++ b/public/index.html
@@ -6959,6 +6959,7 @@
           <button type="button" class="settings-subtab-button" data-settings-tab="chatWidget" role="tab" aria-selected="false">Chat Widget</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="postLogin" role="tab" aria-selected="false">Post-login Sync</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="email" role="tab" aria-selected="false">Email Notifications</button>
+          <button type="button" class="settings-subtab-button" data-settings-tab="careerPage" role="tab" aria-selected="false">Career Page</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="apiTools" role="tab" aria-selected="false">API Testing Tools</button>
         </div>
 
@@ -7188,6 +7189,58 @@
             </button>
           </form>
           <div id="postLoginSettingsStatus" class="settings-status text-muted"></div>
+        </div>
+        </div>
+
+
+        <div class="settings-subtab-panel" data-settings-tab-panel="careerPage">
+        <div class="md-card">
+          <div class="card-title">
+            <span class="material-symbols-rounded">build</span>
+            Career Page Builder
+          </div>
+          <p class="card-subtitle">Build custom HTML sections for your careers page header, updates, content, and footer.</p>
+          <form id="careerPageSettingsForm" class="settings-form">
+            <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="careerPageHeaderHtml">Header HTML</label>
+              <div class="md-input-wrapper md-input-wrapper--textarea">
+                <span class="material-symbols-rounded">vertical_align_top</span>
+                <textarea id="careerPageHeaderHtml" class="md-input md-input--textarea" rows="6" placeholder="Add custom HTML for the top of the careers page"></textarea>
+              </div>
+            </div>
+
+            <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="careerPageUpdatesHtml">Updates HTML</label>
+              <div class="md-input-wrapper md-input-wrapper--textarea">
+                <span class="material-symbols-rounded">campaign</span>
+                <textarea id="careerPageUpdatesHtml" class="md-input md-input--textarea" rows="6" placeholder="Add custom HTML for career updates or announcements"></textarea>
+              </div>
+            </div>
+
+            <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="careerPageContentHtml">Content HTML</label>
+              <div class="md-input-wrapper md-input-wrapper--textarea">
+                <span class="material-symbols-rounded">article</span>
+                <textarea id="careerPageContentHtml" class="md-input md-input--textarea" rows="8" placeholder="Add main careers page HTML content"></textarea>
+              </div>
+            </div>
+
+            <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="careerPageFooterHtml">Footer HTML</label>
+              <div class="md-input-wrapper md-input-wrapper--textarea">
+                <span class="material-symbols-rounded">vertical_align_bottom</span>
+                <textarea id="careerPageFooterHtml" class="md-input md-input--textarea" rows="6" placeholder="Add custom HTML for the careers page footer"></textarea>
+              </div>
+            </div>
+
+            <button type="submit" class="md-button md-button--filled md-button--small settings-form__submit">
+              <span class="material-symbols-rounded">save</span>
+              Save career page
+            </button>
+          </form>
+          <div id="careerPageSettingsStatus" class="settings-status text-muted"></div>
+          <div class="settings-form__help" style="margin-top: 12px;">Preview</div>
+          <iframe id="careerPageBuilderPreview" title="Career page preview" style="width: 100%; min-height: 320px; border: 1px solid var(--md-outline, #d0d7de); border-radius: 12px; background: #fff;"></iframe>
         </div>
         </div>
 


### PR DESCRIPTION
### Motivation
- Provide a simple, admin-editable HTML builder so managers can customize the public careers page (header, updates, content, footer) from the existing Settings UI. 
- Persist and serve those custom sections from the server so the public careers page can be overridden without touching templates.

### Description
- Added backend helpers and endpoints to persist career page HTML with normalization: `normalizeCareerPageHtml` and `getCareerPageSettingsPayload`, and routes `GET /public/settings/career-page`, `GET /settings/career-page`, and `PUT /settings/career-page` in `server.js`.
- Introduced a new "Career Page" subtab in the Settings UI (`public/index.html`) containing a form with textareas for `Header`, `Updates`, `Content`, and `Footer`, plus a live preview iframe (`careerPageBuilderPreview`).
- Implemented client-side logic in `public/index.js` to load/save settings, manage state (`careerPageSettings*`), render the preview (`getCareerPageBuilderTemplate` / `srcdoc`), and hook input/form listeners to update the preview and submit changes.
- Updated the public careers page (`public/careers.html` / `public/careers.js`) to expose section containers (`careerCustomHeader`, `careerCustomUpdates`, `careerCustomContent`, `careerCustomFooter`) and a `loadCareerPageBuilderSettings` call that applies saved HTML into those regions when present.

### Testing
- `node --check public/index.js` — passed.
- `node --check public/careers.js` — passed.
- `node --check server.js` — passed.
- `npm test` — all existing test suites passed.
- `npm start` initially failed in this environment due to a missing `OPENAI_API_KEY` (expected runtime dependency), and `OPENAI_API_KEY=dummy npm start` was used to start the server for local validation; an automated Playwright attempt to capture a screenshot failed due to the browser process crashing (SIGSEGV) in this container environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69959f34ec3c8332ac1c66a155c5f901)