### PR TITLE
Align Career Page Builder with live /careers template sections

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7199,7 +7199,7 @@
             <span class="material-symbols-rounded">build</span>
             Career Page Builder
           </div>
-          <p class="card-subtitle">Build custom HTML sections for your careers page header, updates, content, and footer.</p>
+          <p class="card-subtitle">Starts from the live <code>/careers</code> section-by-section template. Edit text and hyperlinks to match your branding while keeping the same layout.</p>
           <form id="careerPageSettingsForm" class="settings-form">
             <div class="settings-form__fields settings-form__fields--full">
               <label class="md-label" for="careerPageHeaderHtml">Header HTML</label>

--- a/public/index.js
+++ b/public/index.js
@@ -4999,16 +4999,34 @@ function getCareerPageBuilderTemplate(settings = {}) {
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="https://cdn.tailwindcss.com"><\/script>
   <style>
-    body { font-family: Inter, Arial, sans-serif; margin: 0; color: #1f2937; background: #f8fafc; }
-    .career-preview-section { max-width: 960px; margin: 16px auto; padding: 16px; background: #ffffff; border-radius: 12px; }
+    body { font-family: Inter, Arial, sans-serif; margin: 0; color: #1f2937; background: #f9fafb; }
   </style>
 </head>
-<body>
-  <section class="career-preview-section">${header || '<p><em>No header HTML</em></p>'}</section>
-  <section class="career-preview-section">${updates || '<p><em>No updates HTML</em></p>'}</section>
-  <section class="career-preview-section">${content || '<p><em>No content HTML</em></p>'}</section>
-  <section class="career-preview-section">${footer || '<p><em>No footer HTML</em></p>'}</section>
+<body class="bg-gray-50 text-gray-900">
+  <main>
+    <section class="bg-gradient-to-r from-blue-900 via-blue-700 to-blue-500 text-white">
+      ${header || '<div class="max-w-5xl mx-auto px-6 py-16"><p><em>No header HTML</em></p></div>'}
+    </section>
+    <section class="max-w-5xl mx-auto px-6 -mt-10">
+      ${updates || '<div class="bg-white rounded-2xl shadow-lg p-6 sm:p-8"><p><em>No updates HTML</em></p></div>'}
+    </section>
+    <section class="bg-gray-50 py-12 mt-12">
+      <div class="max-w-5xl mx-auto px-6">
+        <div class="text-center mb-8">
+          <h3 class="text-3xl font-semibold text-gray-900">Open Positions</h3>
+          <p class="mt-2 text-gray-600">This list is rendered live on <strong>/careers</strong>.</p>
+        </div>
+      </div>
+    </section>
+    <section class="max-w-5xl mx-auto px-6 pb-16">
+      ${content || '<div class="bg-white rounded-xl shadow p-6 sm:p-8"><p><em>No content HTML</em></p></div>'}
+    </section>
+  </main>
+  <footer class="bg-gray-900 text-gray-300 text-sm py-6 mt-10">
+    ${footer || '<div class="max-w-5xl mx-auto px-6 text-center"><p><em>No footer HTML</em></p></div>'}
+  </footer>
 </body>
 </html>`;
 }

--- a/server.js
+++ b/server.js
@@ -4057,13 +4057,36 @@ init().then(async () => {
     return value.trim().slice(0, maxLength);
   }
 
+  const DEFAULT_CAREER_PAGE_TEMPLATE = {
+    header: `<div class="max-w-5xl mx-auto px-6 py-16">
+  <p class="text-sm uppercase tracking-widest text-blue-100">Brillar Careers</p>
+  <h1 class="text-4xl sm:text-5xl font-bold mt-4">Your Digital Transformation Partner</h1>
+  <h2 class="text-2xl sm:text-3xl font-semibold mt-2 text-blue-100">Transforming tomorrow</h2>
+  <p class="mt-4 max-w-3xl text-lg text-blue-100">Join Brillar and help drive digital transformation across Southeast Asia.</p>
+  <div class="mt-8">
+    <a id="view-open-positions" href="#open-positions" class="inline-block px-6 py-3 bg-white text-blue-700 font-semibold rounded-md shadow hover:bg-blue-50">View Open Positions</a>
+  </div>
+</div>`,
+    updates: `<div class="bg-white rounded-2xl shadow-lg p-6 sm:p-8">
+  <h3 class="text-2xl font-semibold text-gray-900">Careers at Brillar</h3>
+  <p class="mt-3 text-gray-600">At Brillar, we are passionate about empowering organizations through technology. Join a team that values innovation, collaboration, and making a meaningful impact for our partners across the region.</p>
+</div>`,
+    content: `<div id="job-detail" class="bg-white rounded-xl shadow p-6 sm:p-8">
+  <h3 class="text-xl font-semibold text-gray-900">Explore our openings</h3>
+  <p class="text-gray-600 mt-2">Select a role to view details and apply.</p>
+</div>`,
+    footer: `<div class="max-w-5xl mx-auto px-6 text-center space-y-1">
+  <p>© Brillar. All rights reserved.</p>
+</div>`
+  };
+
   function getCareerPageSettingsPayload(stored) {
     const source = stored && typeof stored === 'object' ? stored : {};
     return {
-      header: normalizeCareerPageHtml(source.header),
-      updates: normalizeCareerPageHtml(source.updates),
-      content: normalizeCareerPageHtml(source.content),
-      footer: normalizeCareerPageHtml(source.footer)
+      header: normalizeCareerPageHtml(source.header) || DEFAULT_CAREER_PAGE_TEMPLATE.header,
+      updates: normalizeCareerPageHtml(source.updates) || DEFAULT_CAREER_PAGE_TEMPLATE.updates,
+      content: normalizeCareerPageHtml(source.content) || DEFAULT_CAREER_PAGE_TEMPLATE.content,
+      footer: normalizeCareerPageHtml(source.footer) || DEFAULT_CAREER_PAGE_TEMPLATE.footer
     };
   }
 


### PR DESCRIPTION
### Motivation
- Make the admin Career Page Builder present the same section-by-section layout as the public `/careers` page so edits (text and hyperlinks) reflect the real page structure immediately.
- Provide sensible, editable defaults for header, updates, content, and footer so the builder is usable out-of-the-box and preserves branding-aware markup.

### Description
- Added a `DEFAULT_CAREER_PAGE_TEMPLATE` in `server.js` containing header, updates, content, and footer HTML that mirrors `public/careers.html` structure.
- Updated `getCareerPageSettingsPayload` in `server.js` to return normalized stored values or fall back to the new defaults for each section.
- Reworked the builder preview HTML in `public/index.js` (`getCareerPageBuilderTemplate`) to render the `/careers` layout (hero, updates card, open-positions band, content area, footer) and include Tailwind so previews match the live styling.
- Clarified the Career Page Builder helper copy in `public/index.html` to explain that the builder starts from the live `/careers` template and that admins can edit text and hyperlinks to customize branding.

### Testing
- Performed syntax checks with `node --check server.js`, `node --check public/index.js`, and `node --check public/careers.js`, all of which succeeded.
- Ran the automated test suite with `npm test -- --test-reporter=spec`, which passed (9 passing tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995c34c8748833295f3e4e342b58dd8)