### PR TITLE
Add configurable header banner color to Career Page Builder

### DIFF
--- a/public/careers.js
+++ b/public/careers.js
@@ -8,6 +8,12 @@ const careerCustomUpdatesEl = document.getElementById('careerCustomUpdates');
 const careerCustomContentEl = document.getElementById('careerCustomContent');
 const careerCustomFooterEl = document.getElementById('careerCustomFooter');
 
+function normalizeHeaderBannerColor(value) {
+  if (typeof value !== 'string') return '';
+  const normalized = value.trim();
+  return /^#[0-9a-fA-F]{6}$/.test(normalized) ? normalized : '';
+}
+
 async function fetchJson(url, options = {}) {
   const res = await fetch(url, options);
   if (!res.ok) {
@@ -43,6 +49,8 @@ function applyCustomCareerSection(element, html) {
 async function loadCareerPageBuilderSettings() {
   try {
     const settings = await fetchJson('/public/settings/career-page');
+    const headerBackgroundColor = normalizeHeaderBannerColor(settings?.headerBackgroundColor) || '#1e3a8a';
+    if (careerCustomHeaderEl) careerCustomHeaderEl.style.backgroundColor = headerBackgroundColor;
     applyCustomCareerSection(careerCustomHeaderEl, settings?.header);
     applyCustomCareerSection(careerCustomUpdatesEl, settings?.updates);
     applyCustomCareerSection(careerCustomContentEl, settings?.content);

--- a/public/index.html
+++ b/public/index.html
@@ -7202,6 +7202,14 @@
           <p class="card-subtitle">Starts from the live <code>/careers</code> section-by-section template. Edit text and hyperlinks to match your branding while keeping the same layout.</p>
           <form id="careerPageSettingsForm" class="settings-form">
             <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="careerPageHeaderBackgroundColor">Header banner background color</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">palette</span>
+                <input id="careerPageHeaderBackgroundColor" type="color" class="md-input" value="#1e3a8a" />
+              </div>
+            </div>
+
+            <div class="settings-form__fields settings-form__fields--full">
               <label class="md-label" for="careerPageHeaderHtml">Header HTML</label>
               <div class="md-input-wrapper md-input-wrapper--textarea">
                 <span class="material-symbols-rounded">vertical_align_top</span>

--- a/public/index.js
+++ b/public/index.js
@@ -4990,6 +4990,9 @@ function updateSettingsSubtab(name = 'organization') {
 }
 
 function getCareerPageBuilderTemplate(settings = {}) {
+  const headerBackgroundColor = typeof settings?.headerBackgroundColor === 'string' && /^#[0-9a-fA-F]{6}$/.test(settings.headerBackgroundColor)
+    ? settings.headerBackgroundColor
+    : '#1e3a8a';
   const header = typeof settings?.header === 'string' ? settings.header : '';
   const updates = typeof settings?.updates === 'string' ? settings.updates : '';
   const content = typeof settings?.content === 'string' ? settings.content : '';
@@ -5006,7 +5009,7 @@ function getCareerPageBuilderTemplate(settings = {}) {
 </head>
 <body class="bg-gray-50 text-gray-900">
   <main>
-    <section class="bg-gradient-to-r from-blue-900 via-blue-700 to-blue-500 text-white">
+    <section class="text-white" style="background-color: ${headerBackgroundColor};">
       ${header || '<div class="max-w-5xl mx-auto px-6 py-16"><p><em>No header HTML</em></p></div>'}
     </section>
     <section class="max-w-5xl mx-auto px-6 -mt-10">
@@ -5041,10 +5044,12 @@ function setCareerPageSettingsStatus(message, type = 'info') {
 }
 
 function renderCareerPageSettingsForm() {
+  const headerBgColorInput = document.getElementById('careerPageHeaderBackgroundColor');
   const headerInput = document.getElementById('careerPageHeaderHtml');
   const updatesInput = document.getElementById('careerPageUpdatesHtml');
   const contentInput = document.getElementById('careerPageContentHtml');
   const footerInput = document.getElementById('careerPageFooterHtml');
+  if (headerBgColorInput) headerBgColorInput.value = careerPageSettings?.headerBackgroundColor || '#1e3a8a';
   if (headerInput) headerInput.value = careerPageSettings?.header || '';
   if (updatesInput) updatesInput.value = careerPageSettings?.updates || '';
   if (contentInput) contentInput.value = careerPageSettings?.content || '';
@@ -5055,11 +5060,13 @@ function renderCareerPageSettingsForm() {
 function updateCareerPagePreview() {
   const previewEl = document.getElementById('careerPageBuilderPreview');
   if (!previewEl) return;
+  const headerBgColorInput = document.getElementById('careerPageHeaderBackgroundColor');
   const headerInput = document.getElementById('careerPageHeaderHtml');
   const updatesInput = document.getElementById('careerPageUpdatesHtml');
   const contentInput = document.getElementById('careerPageContentHtml');
   const footerInput = document.getElementById('careerPageFooterHtml');
   const previewSettings = {
+    headerBackgroundColor: headerBgColorInput?.value || '#1e3a8a',
     header: headerInput?.value || '',
     updates: updatesInput?.value || '',
     content: contentInput?.value || '',
@@ -5104,6 +5111,7 @@ async function loadCareerPageSettings({ force = false, silent = false } = {}) {
 async function onCareerPageSettingsSubmit(ev) {
   ev.preventDefault();
   const payload = {
+    headerBackgroundColor: document.getElementById('careerPageHeaderBackgroundColor')?.value || '#1e3a8a',
     header: document.getElementById('careerPageHeaderHtml')?.value || '',
     updates: document.getElementById('careerPageUpdatesHtml')?.value || '',
     content: document.getElementById('careerPageContentHtml')?.value || '',
@@ -9783,7 +9791,7 @@ async function init() {
   if (postLoginForm) postLoginForm.addEventListener('submit', onPostLoginSettingsSubmit);
   const careerPageForm = document.getElementById('careerPageSettingsForm');
   if (careerPageForm) careerPageForm.addEventListener('submit', onCareerPageSettingsSubmit);
-  ['careerPageHeaderHtml', 'careerPageUpdatesHtml', 'careerPageContentHtml', 'careerPageFooterHtml'].forEach(id => {
+  ['careerPageHeaderBackgroundColor', 'careerPageHeaderHtml', 'careerPageUpdatesHtml', 'careerPageContentHtml', 'careerPageFooterHtml'].forEach(id => {
     const input = document.getElementById(id);
     if (input) input.addEventListener('input', updateCareerPagePreview);
   });

--- a/server.js
+++ b/server.js
@@ -4057,7 +4057,14 @@ init().then(async () => {
     return value.trim().slice(0, maxLength);
   }
 
+  function normalizeCareerPageColor(value) {
+    if (typeof value !== 'string') return '';
+    const normalized = value.trim();
+    return /^#[0-9a-fA-F]{6}$/.test(normalized) ? normalized.toLowerCase() : '';
+  }
+
   const DEFAULT_CAREER_PAGE_TEMPLATE = {
+    headerBackgroundColor: '#1e3a8a',
     header: `<div class="max-w-5xl mx-auto px-6 py-16">
   <p class="text-sm uppercase tracking-widest text-blue-100">Brillar Careers</p>
   <h1 class="text-4xl sm:text-5xl font-bold mt-4">Your Digital Transformation Partner</h1>
@@ -4083,6 +4090,7 @@ init().then(async () => {
   function getCareerPageSettingsPayload(stored) {
     const source = stored && typeof stored === 'object' ? stored : {};
     return {
+      headerBackgroundColor: normalizeCareerPageColor(source.headerBackgroundColor) || DEFAULT_CAREER_PAGE_TEMPLATE.headerBackgroundColor,
       header: normalizeCareerPageHtml(source.header) || DEFAULT_CAREER_PAGE_TEMPLATE.header,
       updates: normalizeCareerPageHtml(source.updates) || DEFAULT_CAREER_PAGE_TEMPLATE.updates,
       content: normalizeCareerPageHtml(source.content) || DEFAULT_CAREER_PAGE_TEMPLATE.content,
@@ -4192,6 +4200,7 @@ init().then(async () => {
   app.put('/settings/career-page', authRequired, managerOnly, async (req, res) => {
     try {
       const payload = {
+        headerBackgroundColor: normalizeCareerPageColor(req.body?.headerBackgroundColor) || DEFAULT_CAREER_PAGE_TEMPLATE.headerBackgroundColor,
         header: normalizeCareerPageHtml(req.body?.header),
         updates: normalizeCareerPageHtml(req.body?.updates),
         content: normalizeCareerPageHtml(req.body?.content),


### PR DESCRIPTION
### Motivation
- Enable managers to customize the background color of the top careers banner (the section that contains the “View Open Positions” CTA) from the Career Page Builder settings.

### Description
- Add a validated `headerBackgroundColor` field to the career-page settings payload and persistence, with `normalizeCareerPageColor` and a default `#1e3a8a` in `server.js`.
- Add a color picker input (`#careerPageHeaderBackgroundColor`) to the Career Page Builder form in `public/index.html` and wire it into the settings UI so the value is read/saved (`public/index.js`).
- Use the selected color for the admin preview by passing `headerBackgroundColor` into `getCareerPageBuilderTemplate` and applying an inline `style="background-color: ..."` to the header section in the preview (`public/index.js`).
- Apply the configured color on the live `/careers` page when settings are loaded by setting `careerCustomHeaderEl.style.backgroundColor` in `public/careers.js`.

### Testing
- Ran static checks with `node --check public/index.js`, `node --check public/careers.js`, and `node --check server.js`, which completed without errors.
- Ran the project tests with `OPENAI_API_KEY=dummy npm test`, and all unit tests passed (`9` tests, `0` failed).
- Started the server (`OPENAI_API_KEY=dummy npm start`) successfully in this environment; an attempted Playwright screenshot run crashed due to the Chromium process in this environment (SIGSEGV), so no visual artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995c6295a94833284e249961039706c)