### PR TITLE
Make careers logo and navigation links configurable via Career Page settings

### DIFF
--- a/public/careers.html
+++ b/public/careers.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-50 text-gray-900">
   <header class="sticky top-0 z-20">
     <nav class="bg-white shadow px-8 py-4 flex items-center justify-between max-w-6xl mx-auto">
-      <a href="https://www.brillar.io" class="flex items-center space-x-2">
+      <a id="careersBrandLogoLink" href="https://www.brillar.io" class="flex items-center space-x-2">
         <img
           id="careersBrandLogo"
           src="/logo.png"
@@ -21,12 +21,12 @@
         />
       </a>
       <div class="flex items-center space-x-6 text-sm font-medium text-gray-700">
-        <a href="https://www.brillar.io/" class="hover:text-blue-600">Home</a>
-        <a href="https://www.brillar.io/#about" class="hover:text-blue-600">About</a>
-        <a href="https://www.brillar.io/#solutions" class="hover:text-blue-600">Solutions</a>
-        <a href="https://www.brillar.io/#partners" class="hover:text-blue-600">Partners</a>
-        <a href="https://www.brillar.io/#contact" class="hover:text-blue-600">Contact</a>
-        <a href="https://hr.brillar.ai/careers" class="text-blue-600">Careers</a>
+        <a id="careerNavHome" href="https://www.brillar.io/" class="hover:text-blue-600">Home</a>
+        <a id="careerNavAbout" href="https://www.brillar.io/#about" class="hover:text-blue-600">About</a>
+        <a id="careerNavSolutions" href="https://www.brillar.io/#solutions" class="hover:text-blue-600">Solutions</a>
+        <a id="careerNavPartners" href="https://www.brillar.io/#partners" class="hover:text-blue-600">Partners</a>
+        <a id="careerNavContact" href="https://www.brillar.io/#contact" class="hover:text-blue-600">Contact</a>
+        <a id="careerNavCareers" href="/careers" class="text-blue-600">Careers</a>
       </div>
     </nav>
   </header>

--- a/public/careers.js
+++ b/public/careers.js
@@ -1,6 +1,27 @@
 const jobListEl = document.getElementById('job-list');
 const jobDetailEl = document.getElementById('job-detail');
 const careersBrandLogoEl = document.getElementById('careersBrandLogo');
+const careersBrandLogoLinkEl = document.getElementById('careersBrandLogoLink');
+const careerNavLinkElements = {
+  home: document.getElementById('careerNavHome'),
+  about: document.getElementById('careerNavAbout'),
+  solutions: document.getElementById('careerNavSolutions'),
+  partners: document.getElementById('careerNavPartners'),
+  contact: document.getElementById('careerNavContact'),
+  careers: document.getElementById('careerNavCareers')
+};
+
+const DEFAULT_CAREER_PAGE_LINKS = {
+  logoLink: 'https://www.brillar.io',
+  menuLinks: {
+    home: 'https://www.brillar.io/',
+    about: 'https://www.brillar.io/#about',
+    solutions: 'https://www.brillar.io/#solutions',
+    partners: 'https://www.brillar.io/#partners',
+    contact: 'https://www.brillar.io/#contact',
+    careers: '/careers'
+  }
+};
 const DEFAULT_ORGANIZATION_LOGO_URL = '/logo.png';
 
 const careerCustomHeaderEl = document.getElementById('careerCustomHeader');
@@ -39,6 +60,36 @@ async function loadOrganizationBranding() {
 }
 
 
+
+function resolveCareerPageLinks(settings) {
+  const menuLinks = settings && typeof settings === 'object' && settings.menuLinks && typeof settings.menuLinks === 'object'
+    ? settings.menuLinks
+    : {};
+
+  return {
+    logoLink: typeof settings?.logoLink === 'string' && settings.logoLink.trim()
+      ? settings.logoLink.trim()
+      : DEFAULT_CAREER_PAGE_LINKS.logoLink,
+    menuLinks: {
+      home: typeof menuLinks.home === 'string' && menuLinks.home.trim() ? menuLinks.home.trim() : DEFAULT_CAREER_PAGE_LINKS.menuLinks.home,
+      about: typeof menuLinks.about === 'string' && menuLinks.about.trim() ? menuLinks.about.trim() : DEFAULT_CAREER_PAGE_LINKS.menuLinks.about,
+      solutions: typeof menuLinks.solutions === 'string' && menuLinks.solutions.trim() ? menuLinks.solutions.trim() : DEFAULT_CAREER_PAGE_LINKS.menuLinks.solutions,
+      partners: typeof menuLinks.partners === 'string' && menuLinks.partners.trim() ? menuLinks.partners.trim() : DEFAULT_CAREER_PAGE_LINKS.menuLinks.partners,
+      contact: typeof menuLinks.contact === 'string' && menuLinks.contact.trim() ? menuLinks.contact.trim() : DEFAULT_CAREER_PAGE_LINKS.menuLinks.contact,
+      careers: typeof menuLinks.careers === 'string' && menuLinks.careers.trim() ? menuLinks.careers.trim() : DEFAULT_CAREER_PAGE_LINKS.menuLinks.careers
+    }
+  };
+}
+
+function applyCareerPageLinks(settings) {
+  const links = resolveCareerPageLinks(settings);
+  if (careersBrandLogoLinkEl) careersBrandLogoLinkEl.href = links.logoLink;
+  Object.entries(careerNavLinkElements).forEach(([key, element]) => {
+    if (!element) return;
+    element.href = links.menuLinks[key];
+  });
+}
+
 function applyCustomCareerSection(element, html) {
   if (!element || typeof html !== 'string') return;
   const trimmed = html.trim();
@@ -49,6 +100,7 @@ function applyCustomCareerSection(element, html) {
 async function loadCareerPageBuilderSettings() {
   try {
     const settings = await fetchJson('/public/settings/career-page');
+    applyCareerPageLinks(settings);
     const headerBackgroundColor = normalizeHeaderBannerColor(settings?.headerBackgroundColor) || '#1e3a8a';
     if (careerCustomHeaderEl) {
       // The static template uses Tailwind gradient classes. Clear any gradient image
@@ -61,6 +113,7 @@ async function loadCareerPageBuilderSettings() {
     applyCustomCareerSection(careerCustomContentEl, settings?.content);
     applyCustomCareerSection(careerCustomFooterEl, settings?.footer);
   } catch (_error) {
+    applyCareerPageLinks(null);
     // Keep default careers layout when custom builder settings are unavailable.
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -7202,6 +7202,62 @@
           <p class="card-subtitle">Starts from the live <code>/careers</code> section-by-section template. Edit text and hyperlinks to match your branding while keeping the same layout.</p>
           <form id="careerPageSettingsForm" class="settings-form">
             <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="careerPageLogoLink">Logo click-through link</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">link</span>
+                <input id="careerPageLogoLink" type="url" class="md-input" value="https://www.brillar.io" placeholder="https://www.brillar.io" />
+              </div>
+            </div>
+
+            <div class="settings-form__fields">
+              <label class="md-label" for="careerPageMenuHomeLink">Home link</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">home</span>
+                <input id="careerPageMenuHomeLink" type="text" class="md-input" value="https://www.brillar.io/" placeholder="https://www.brillar.io/" />
+              </div>
+            </div>
+
+            <div class="settings-form__fields">
+              <label class="md-label" for="careerPageMenuAboutLink">About link</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">info</span>
+                <input id="careerPageMenuAboutLink" type="text" class="md-input" value="https://www.brillar.io/#about" placeholder="https://www.brillar.io/#about" />
+              </div>
+            </div>
+
+            <div class="settings-form__fields">
+              <label class="md-label" for="careerPageMenuSolutionsLink">Solutions link</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">apps</span>
+                <input id="careerPageMenuSolutionsLink" type="text" class="md-input" value="https://www.brillar.io/#solutions" placeholder="https://www.brillar.io/#solutions" />
+              </div>
+            </div>
+
+            <div class="settings-form__fields">
+              <label class="md-label" for="careerPageMenuPartnersLink">Partners link</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">handshake</span>
+                <input id="careerPageMenuPartnersLink" type="text" class="md-input" value="https://www.brillar.io/#partners" placeholder="https://www.brillar.io/#partners" />
+              </div>
+            </div>
+
+            <div class="settings-form__fields">
+              <label class="md-label" for="careerPageMenuContactLink">Contact link</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">mail</span>
+                <input id="careerPageMenuContactLink" type="text" class="md-input" value="https://www.brillar.io/#contact" placeholder="https://www.brillar.io/#contact" />
+              </div>
+            </div>
+
+            <div class="settings-form__fields">
+              <label class="md-label" for="careerPageMenuCareersLink">Careers link</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">work</span>
+                <input id="careerPageMenuCareersLink" type="text" class="md-input" value="/careers" placeholder="/careers" />
+              </div>
+            </div>
+
+            <div class="settings-form__fields settings-form__fields--full">
               <label class="md-label" for="careerPageHeaderBackgroundColor">Header banner background color</label>
               <div class="md-input-wrapper">
                 <span class="material-symbols-rounded">palette</span>

--- a/public/index.js
+++ b/public/index.js
@@ -5044,11 +5044,25 @@ function setCareerPageSettingsStatus(message, type = 'info') {
 }
 
 function renderCareerPageSettingsForm() {
+  const logoLinkInput = document.getElementById('careerPageLogoLink');
+  const homeLinkInput = document.getElementById('careerPageMenuHomeLink');
+  const aboutLinkInput = document.getElementById('careerPageMenuAboutLink');
+  const solutionsLinkInput = document.getElementById('careerPageMenuSolutionsLink');
+  const partnersLinkInput = document.getElementById('careerPageMenuPartnersLink');
+  const contactLinkInput = document.getElementById('careerPageMenuContactLink');
+  const careersLinkInput = document.getElementById('careerPageMenuCareersLink');
   const headerBgColorInput = document.getElementById('careerPageHeaderBackgroundColor');
   const headerInput = document.getElementById('careerPageHeaderHtml');
   const updatesInput = document.getElementById('careerPageUpdatesHtml');
   const contentInput = document.getElementById('careerPageContentHtml');
   const footerInput = document.getElementById('careerPageFooterHtml');
+  if (logoLinkInput) logoLinkInput.value = careerPageSettings?.logoLink || 'https://www.brillar.io';
+  if (homeLinkInput) homeLinkInput.value = careerPageSettings?.menuLinks?.home || 'https://www.brillar.io/';
+  if (aboutLinkInput) aboutLinkInput.value = careerPageSettings?.menuLinks?.about || 'https://www.brillar.io/#about';
+  if (solutionsLinkInput) solutionsLinkInput.value = careerPageSettings?.menuLinks?.solutions || 'https://www.brillar.io/#solutions';
+  if (partnersLinkInput) partnersLinkInput.value = careerPageSettings?.menuLinks?.partners || 'https://www.brillar.io/#partners';
+  if (contactLinkInput) contactLinkInput.value = careerPageSettings?.menuLinks?.contact || 'https://www.brillar.io/#contact';
+  if (careersLinkInput) careersLinkInput.value = careerPageSettings?.menuLinks?.careers || '/careers';
   if (headerBgColorInput) headerBgColorInput.value = careerPageSettings?.headerBackgroundColor || '#1e3a8a';
   if (headerInput) headerInput.value = careerPageSettings?.header || '';
   if (updatesInput) updatesInput.value = careerPageSettings?.updates || '';
@@ -5111,6 +5125,15 @@ async function loadCareerPageSettings({ force = false, silent = false } = {}) {
 async function onCareerPageSettingsSubmit(ev) {
   ev.preventDefault();
   const payload = {
+    logoLink: document.getElementById('careerPageLogoLink')?.value || 'https://www.brillar.io',
+    menuLinks: {
+      home: document.getElementById('careerPageMenuHomeLink')?.value || 'https://www.brillar.io/',
+      about: document.getElementById('careerPageMenuAboutLink')?.value || 'https://www.brillar.io/#about',
+      solutions: document.getElementById('careerPageMenuSolutionsLink')?.value || 'https://www.brillar.io/#solutions',
+      partners: document.getElementById('careerPageMenuPartnersLink')?.value || 'https://www.brillar.io/#partners',
+      contact: document.getElementById('careerPageMenuContactLink')?.value || 'https://www.brillar.io/#contact',
+      careers: document.getElementById('careerPageMenuCareersLink')?.value || '/careers'
+    },
     headerBackgroundColor: document.getElementById('careerPageHeaderBackgroundColor')?.value || '#1e3a8a',
     header: document.getElementById('careerPageHeaderHtml')?.value || '',
     updates: document.getElementById('careerPageUpdatesHtml')?.value || '',
@@ -9791,7 +9814,7 @@ async function init() {
   if (postLoginForm) postLoginForm.addEventListener('submit', onPostLoginSettingsSubmit);
   const careerPageForm = document.getElementById('careerPageSettingsForm');
   if (careerPageForm) careerPageForm.addEventListener('submit', onCareerPageSettingsSubmit);
-  ['careerPageHeaderBackgroundColor', 'careerPageHeaderHtml', 'careerPageUpdatesHtml', 'careerPageContentHtml', 'careerPageFooterHtml'].forEach(id => {
+  ['careerPageLogoLink', 'careerPageMenuHomeLink', 'careerPageMenuAboutLink', 'careerPageMenuSolutionsLink', 'careerPageMenuPartnersLink', 'careerPageMenuContactLink', 'careerPageMenuCareersLink', 'careerPageHeaderBackgroundColor', 'careerPageHeaderHtml', 'careerPageUpdatesHtml', 'careerPageContentHtml', 'careerPageFooterHtml'].forEach(id => {
     const input = document.getElementById(id);
     if (input) input.addEventListener('input', updateCareerPagePreview);
   });

--- a/server.js
+++ b/server.js
@@ -4063,7 +4063,32 @@ init().then(async () => {
     return /^#[0-9a-fA-F]{6}$/.test(normalized) ? normalized.toLowerCase() : '';
   }
 
+  function normalizeCareerPageLink(value) {
+    if (typeof value !== 'string') return '';
+    const trimmed = value.trim();
+    if (!trimmed) return '';
+    if (trimmed.startsWith('/') || trimmed.startsWith('#')) return trimmed;
+    try {
+      // eslint-disable-next-line no-new
+      new URL(trimmed);
+    } catch (error) {
+      return '';
+    }
+    return trimmed;
+  }
+
+  const DEFAULT_CAREER_PAGE_MENU_LINKS = {
+    home: 'https://www.brillar.io/',
+    about: 'https://www.brillar.io/#about',
+    solutions: 'https://www.brillar.io/#solutions',
+    partners: 'https://www.brillar.io/#partners',
+    contact: 'https://www.brillar.io/#contact',
+    careers: '/careers'
+  };
+
   const DEFAULT_CAREER_PAGE_TEMPLATE = {
+    logoLink: 'https://www.brillar.io',
+    menuLinks: DEFAULT_CAREER_PAGE_MENU_LINKS,
     headerBackgroundColor: '#1e3a8a',
     header: `<div class="max-w-5xl mx-auto px-6 py-16">
   <p class="text-sm uppercase tracking-widest text-blue-100">Brillar Careers</p>
@@ -4090,6 +4115,15 @@ init().then(async () => {
   function getCareerPageSettingsPayload(stored) {
     const source = stored && typeof stored === 'object' ? stored : {};
     return {
+      logoLink: normalizeCareerPageLink(source.logoLink) || DEFAULT_CAREER_PAGE_TEMPLATE.logoLink,
+      menuLinks: {
+        home: normalizeCareerPageLink(source?.menuLinks?.home) || DEFAULT_CAREER_PAGE_MENU_LINKS.home,
+        about: normalizeCareerPageLink(source?.menuLinks?.about) || DEFAULT_CAREER_PAGE_MENU_LINKS.about,
+        solutions: normalizeCareerPageLink(source?.menuLinks?.solutions) || DEFAULT_CAREER_PAGE_MENU_LINKS.solutions,
+        partners: normalizeCareerPageLink(source?.menuLinks?.partners) || DEFAULT_CAREER_PAGE_MENU_LINKS.partners,
+        contact: normalizeCareerPageLink(source?.menuLinks?.contact) || DEFAULT_CAREER_PAGE_MENU_LINKS.contact,
+        careers: normalizeCareerPageLink(source?.menuLinks?.careers) || DEFAULT_CAREER_PAGE_MENU_LINKS.careers
+      },
       headerBackgroundColor: normalizeCareerPageColor(source.headerBackgroundColor) || DEFAULT_CAREER_PAGE_TEMPLATE.headerBackgroundColor,
       header: normalizeCareerPageHtml(source.header) || DEFAULT_CAREER_PAGE_TEMPLATE.header,
       updates: normalizeCareerPageHtml(source.updates) || DEFAULT_CAREER_PAGE_TEMPLATE.updates,
@@ -4200,6 +4234,15 @@ init().then(async () => {
   app.put('/settings/career-page', authRequired, managerOnly, async (req, res) => {
     try {
       const payload = {
+        logoLink: normalizeCareerPageLink(req.body?.logoLink) || DEFAULT_CAREER_PAGE_TEMPLATE.logoLink,
+        menuLinks: {
+          home: normalizeCareerPageLink(req.body?.menuLinks?.home) || DEFAULT_CAREER_PAGE_MENU_LINKS.home,
+          about: normalizeCareerPageLink(req.body?.menuLinks?.about) || DEFAULT_CAREER_PAGE_MENU_LINKS.about,
+          solutions: normalizeCareerPageLink(req.body?.menuLinks?.solutions) || DEFAULT_CAREER_PAGE_MENU_LINKS.solutions,
+          partners: normalizeCareerPageLink(req.body?.menuLinks?.partners) || DEFAULT_CAREER_PAGE_MENU_LINKS.partners,
+          contact: normalizeCareerPageLink(req.body?.menuLinks?.contact) || DEFAULT_CAREER_PAGE_MENU_LINKS.contact,
+          careers: normalizeCareerPageLink(req.body?.menuLinks?.careers) || DEFAULT_CAREER_PAGE_MENU_LINKS.careers
+        },
         headerBackgroundColor: normalizeCareerPageColor(req.body?.headerBackgroundColor) || DEFAULT_CAREER_PAGE_TEMPLATE.headerBackgroundColor,
         header: normalizeCareerPageHtml(req.body?.header),
         updates: normalizeCareerPageHtml(req.body?.updates),


### PR DESCRIPTION
### Motivation
- Allow the Careers page logo click-through and the top navigation items (Home, About, Solutions, Partners, Contact, Careers) to be configurable from the Career Page settings instead of being hard-coded in the public template.
- Provide sane defaults and validation so changes are safe and the public careers page degrades to working defaults when no settings are present.

### Description
- Added `normalizeCareerPageLink` and default menu link constants and plugged `logoLink` + `menuLinks` into the career page settings payload so `/public/settings/career-page` and `/settings/career-page` include these fields (with normalization and defaults). (`server.js`).
- Updated the public Careers markup to expose stable element IDs for the logo wrapper and each nav anchor so they can be updated dynamically. (`public/careers.html`).
- Implemented `resolveCareerPageLinks` and `applyCareerPageLinks` in the public careers script and applied loaded settings (with fallback defaults) when the careers page loads. (`public/careers.js`).
- Extended the admin Career Page builder UI with inputs for `logoLink` and each menu link and wired load/save + live preview behavior so the new fields are persisted and previewed in the settings UI. (`public/index.html`, `public/index.js`).

### Testing
- Ran JavaScript static checks via `node --check server.js && node --check public/careers.js && node --check public/index.js`, which passed. 
- Ran the test suite with `npm test`, and the automated tests passed (`9` tests, `0` failures).
- Attempted to start the server with `node server.js` to validate runtime, but startup failed in this environment due to a missing `OPENAI_API_KEY` environment variable, so manual browser validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995ca76f4ec833295f82246be28cc5f)