### PR TITLE
Extend request-portal notifications: templates, backend triggers, and UI toasts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7597,6 +7597,52 @@
                 <textarea id="emailTemplateCancelBody" class="md-input md-input--textarea" rows="3" placeholder="{name}, your leave from {from} to {to} has been cancelled."></textarea>
               </div>
             </div>
+            <div class="settings-form__fields settings-form__fields--full">
+              <span class="md-label">Request portal notification templates</span>
+              <p class="settings-form__help">Use placeholders <code>{requestId}</code>, <code>{requestType}</code>, <code>{status}</code>, <code>{requestedAt}</code>, <code>{closedAt}</code>, and <code>{managerNote}</code>.</p>
+            </div>
+            <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="emailTemplateRequestCreatedSubject">Request created subject</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">subject</span>
+                <input type="text" id="emailTemplateRequestCreatedSubject" class="md-input" placeholder="Request {requestId} created: {requestType}">
+              </div>
+            </div>
+            <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="emailTemplateRequestCreatedBody">Request created body</label>
+              <div class="md-input-wrapper md-input-wrapper--textarea">
+                <span class="material-symbols-rounded">notes</span>
+                <textarea id="emailTemplateRequestCreatedBody" class="md-input md-input--textarea" rows="4" placeholder="A new request ticket has been created."></textarea>
+              </div>
+            </div>
+            <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="emailTemplateRequestUpdatedSubject">Request updated subject</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">update</span>
+                <input type="text" id="emailTemplateRequestUpdatedSubject" class="md-input" placeholder="Request {requestId} updated: {status}">
+              </div>
+            </div>
+            <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="emailTemplateRequestUpdatedBody">Request updated body</label>
+              <div class="md-input-wrapper md-input-wrapper--textarea">
+                <span class="material-symbols-rounded">mail</span>
+                <textarea id="emailTemplateRequestUpdatedBody" class="md-input md-input--textarea" rows="4" placeholder="Your request has been updated."></textarea>
+              </div>
+            </div>
+            <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="emailTemplateRequestClosedSubject">Request closed subject</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">task_alt</span>
+                <input type="text" id="emailTemplateRequestClosedSubject" class="md-input" placeholder="Request {requestId} closed">
+              </div>
+            </div>
+            <div class="settings-form__fields settings-form__fields--full">
+              <label class="md-label" for="emailTemplateRequestClosedBody">Request closed body</label>
+              <div class="md-input-wrapper md-input-wrapper--textarea">
+                <span class="material-symbols-rounded">drafts</span>
+                <textarea id="emailTemplateRequestClosedBody" class="md-input md-input--textarea" rows="4" placeholder="Your request has been closed."></textarea>
+              </div>
+            </div>
             <div class="settings-form__help" id="emailPasswordHelp">Password is stored securely. Leave blank to keep the current password.</div>
             <div class="settings-form__help auth-section auth-section--oauth hidden" id="emailOAuthClientSecretHelp">Client secret is stored securely. Leave blank to keep the current value.</div>
             <div class="settings-form__help auth-section auth-section--oauth hidden" id="emailOAuthRefreshTokenHelp">Provide a refresh token only if using delegated permissions. Leave blank to keep the current value.</div>

--- a/public/index.js
+++ b/public/index.js
@@ -944,7 +944,13 @@ const DEFAULT_LEAVE_EMAIL_TEMPLATES = {
     'Thank you for your understanding.'
   ].join('\n'),
   cancelSubject: 'Leave cancelled',
-  cancelBody: '{name}, your leave from {from} to {to} has been cancelled.'
+  cancelBody: '{name}, your leave from {from} to {to} has been cancelled.',
+  requestCreatedSubject: 'Request {requestId} created: {requestType}',
+  requestCreatedBody: 'A new request ticket has been created.\n\nRequest ID: {requestId}\nRequest type: {requestType}\nStatus: {status}\nRequested at: {requestedAt}',
+  requestUpdatedSubject: 'Request {requestId} updated: {status}',
+  requestUpdatedBody: 'Your request has been updated.\n\nRequest ID: {requestId}\nRequest type: {requestType}\nStatus: {status}\nRequested at: {requestedAt}\n\n{managerNote}',
+  requestClosedSubject: 'Request {requestId} closed',
+  requestClosedBody: 'Your request has been closed.\n\nRequest ID: {requestId}\nRequest type: {requestType}\nStatus: {status}\nRequested at: {requestedAt}\nClosed at: {closedAt}\n\n{managerNote}'
 };
 let emailSettings = null;
 let emailSettingsLoaded = false;
@@ -1834,6 +1840,7 @@ async function onRequestPortalManagerSave(requestId) {
     }
 
     setRequestPortalAllRequestsStatus('Request updated successfully.', 'success');
+    showToast('Request updated successfully.', 'success');
     await Promise.all([
       loadRequestPortalAllRequests({ silent: true }),
       loadRequestPortalMyRequests()
@@ -1941,6 +1948,7 @@ async function onRequestPortalSubmit(event) {
     if (categorySelect) categorySelect.value = '';
 
     setRequestPortalFormStatus(`Request submitted successfully (ID: ${data?.id || 'generated'}).`, 'success');
+    showToast(`Request submitted successfully (ID: ${data?.id || 'generated'}).`, 'success');
     updateRequestPortalSubtab('mine');
     await loadRequestPortalMyRequests();
   } catch (err) {
@@ -7543,6 +7551,12 @@ function renderEmailSettingsForm() {
   const templateRejectBody = document.getElementById('emailTemplateRejectBody');
   const templateCancelSubject = document.getElementById('emailTemplateCancelSubject');
   const templateCancelBody = document.getElementById('emailTemplateCancelBody');
+  const templateRequestCreatedSubject = document.getElementById('emailTemplateRequestCreatedSubject');
+  const templateRequestCreatedBody = document.getElementById('emailTemplateRequestCreatedBody');
+  const templateRequestUpdatedSubject = document.getElementById('emailTemplateRequestUpdatedSubject');
+  const templateRequestUpdatedBody = document.getElementById('emailTemplateRequestUpdatedBody');
+  const templateRequestClosedSubject = document.getElementById('emailTemplateRequestClosedSubject');
+  const templateRequestClosedBody = document.getElementById('emailTemplateRequestClosedBody');
   const settings = emailSettings || {};
   if (enabledInput) enabledInput.checked = Boolean(settings.enabled);
   const provider = settings.provider === 'office365' ? 'office365' : 'custom';
@@ -7650,6 +7664,12 @@ function renderEmailSettingsForm() {
   if (templateRejectBody) templateRejectBody.value = templates.rejectBody || '';
   if (templateCancelSubject) templateCancelSubject.value = templates.cancelSubject || '';
   if (templateCancelBody) templateCancelBody.value = templates.cancelBody || '';
+  if (templateRequestCreatedSubject) templateRequestCreatedSubject.value = templates.requestCreatedSubject || '';
+  if (templateRequestCreatedBody) templateRequestCreatedBody.value = templates.requestCreatedBody || '';
+  if (templateRequestUpdatedSubject) templateRequestUpdatedSubject.value = templates.requestUpdatedSubject || '';
+  if (templateRequestUpdatedBody) templateRequestUpdatedBody.value = templates.requestUpdatedBody || '';
+  if (templateRequestClosedSubject) templateRequestClosedSubject.value = templates.requestClosedSubject || '';
+  if (templateRequestClosedBody) templateRequestClosedBody.value = templates.requestClosedBody || '';
   if (provider !== 'office365') {
     rememberCustomEmailSettings();
   }
@@ -7757,6 +7777,12 @@ async function onEmailSettingsSubmit(ev) {
     const templateRejectBody = document.getElementById('emailTemplateRejectBody');
     const templateCancelSubject = document.getElementById('emailTemplateCancelSubject');
     const templateCancelBody = document.getElementById('emailTemplateCancelBody');
+    const templateRequestCreatedSubject = document.getElementById('emailTemplateRequestCreatedSubject');
+    const templateRequestCreatedBody = document.getElementById('emailTemplateRequestCreatedBody');
+    const templateRequestUpdatedSubject = document.getElementById('emailTemplateRequestUpdatedSubject');
+    const templateRequestUpdatedBody = document.getElementById('emailTemplateRequestUpdatedBody');
+    const templateRequestClosedSubject = document.getElementById('emailTemplateRequestClosedSubject');
+    const templateRequestClosedBody = document.getElementById('emailTemplateRequestClosedBody');
     const recipientInputs = Array.from(document.querySelectorAll('input[name="emailRecipients"]'));
     const selectedRecipients = recipientInputs
       .filter(input => input instanceof HTMLInputElement && input.checked)
@@ -7790,7 +7816,13 @@ async function onEmailSettingsSubmit(ev) {
         rejectSubject: templateRejectSubject?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.rejectSubject,
         rejectBody: templateRejectBody?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.rejectBody,
         cancelSubject: templateCancelSubject?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.cancelSubject,
-        cancelBody: templateCancelBody?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.cancelBody
+        cancelBody: templateCancelBody?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.cancelBody,
+        requestCreatedSubject: templateRequestCreatedSubject?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.requestCreatedSubject,
+        requestCreatedBody: templateRequestCreatedBody?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.requestCreatedBody,
+        requestUpdatedSubject: templateRequestUpdatedSubject?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.requestUpdatedSubject,
+        requestUpdatedBody: templateRequestUpdatedBody?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.requestUpdatedBody,
+        requestClosedSubject: templateRequestClosedSubject?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.requestClosedSubject,
+        requestClosedBody: templateRequestClosedBody?.value?.trim() || DEFAULT_LEAVE_EMAIL_TEMPLATES.requestClosedBody
       }
     };
     const wantsRefreshToken = payload.updateRefreshToken


### PR DESCRIPTION
### Motivation
- Provide email-based notifications for request-portal lifecycle events (created, updated, closed) and allow admins to edit templates in settings. 
- Ensure managers are informed on new tickets and requesters are notified on status/result changes, while also surfacing immediate in-app feedback when email is disabled.

### Description
- Added request-specific email template defaults to `DEFAULT_LEAVE_EMAIL_TEMPLATES` in `server.js` (`requestCreatedSubject/body`, `requestUpdatedSubject/body`, `requestClosedSubject/body`) including placeholders `{requestId}`, `{requestType}`, `{status}`, `{requestedAt}`, `{closedAt}`, and `{managerNote}`.
- Implemented helper functions in `server.js`: `buildRequestTemplateVars`, `sendRequestCreatedNotification`, and `sendRequestUpdateNotification`, and wired them to request lifecycle handlers so creation notifies manager recipients and status/result updates notify the requester.
- Extended email settings persistence/normalization to include the new template keys so `/settings/email` GET/PUT round-trips the request templates.
- Updated frontend settings UI (`public/index.html` + `public/index.js`) to expose fields for the new request templates and to load/save their values via the existing email settings flow.
- Added in-app success toasts in `public/index.js` for request submission and manager save actions to provide near-real-time user awareness even when email notifications are disabled.

### Testing
- Ran `node --check server.js` and `node --check public/index.js` with no syntax errors reported.
- Executed the automated test suite with `npm test` and all tests passed (`9/9` subtests OK).
- Attempted to start the app with `npm start` and validate UI via Playwright, but the local process in this environment required an API key for an OpenAI client and the Playwright navigation failed with `ERR_EMPTY_RESPONSE`, so a live browser screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995f86deaa8833280fe3f2ddeecdea2)