### PR TITLE
Add request fulfillment SLA metrics, manager UI KPIs, and CSV export

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5169,6 +5169,81 @@
               All Requests
             </div>
             <p class="card-subtitle">Managers can filter requests and update fulfillment details.</p>
+
+            <div class="kpi-grid" id="requestPortalMetricsKpiGrid">
+              <div class="kpi-card">
+                <div class="kpi-card__icon kpi-card__icon--info" aria-hidden="true">
+                  <span class="material-symbols-rounded">schedule</span>
+                </div>
+                <div class="kpi-card__content">
+                  <p class="kpi-card__label">Average turnaround</p>
+                  <p id="requestPortalMetricsAverageTurnaround" class="kpi-card__value">--</p>
+                  <p class="kpi-card__meta">Closed requests only</p>
+                </div>
+              </div>
+              <div class="kpi-card">
+                <div class="kpi-card__icon kpi-card__icon--success" aria-hidden="true">
+                  <span class="material-symbols-rounded">insights</span>
+                </div>
+                <div class="kpi-card__content">
+                  <p class="kpi-card__label">Median turnaround</p>
+                  <p id="requestPortalMetricsMedianTurnaround" class="kpi-card__value">--</p>
+                  <p class="kpi-card__meta">SLA baseline median</p>
+                </div>
+              </div>
+              <div class="kpi-card">
+                <div class="kpi-card__icon kpi-card__icon--warning" aria-hidden="true">
+                  <span class="material-symbols-rounded">hourglass_top</span>
+                </div>
+                <div class="kpi-card__content">
+                  <p class="kpi-card__label">Open aging buckets</p>
+                  <p id="requestPortalMetricsOpenAging" class="kpi-card__value">0 / 0 / 0</p>
+                  <p class="kpi-card__meta">0-2d, 3-7d, &gt;7d</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="learning-report-grid" style="margin-bottom: 16px;">
+              <div class="md-card learning-report-card">
+                <div class="learning-report-card-header">
+                  <h4>Category SLA breakdown</h4>
+                </div>
+                <div class="request-portal-table-wrapper">
+                  <table class="data-grid-table request-portal-table">
+                    <thead>
+                      <tr>
+                        <th>Category</th>
+                        <th>Total</th>
+                        <th>Open</th>
+                        <th>In progress</th>
+                        <th>Closed</th>
+                        <th>Avg TAT</th>
+                        <th>Median TAT</th>
+                      </tr>
+                    </thead>
+                    <tbody id="requestPortalMetricsCategoryBody"></tbody>
+                  </table>
+                </div>
+              </div>
+              <div class="md-card learning-report-card">
+                <div class="learning-report-card-header">
+                  <h4>Status slices</h4>
+                </div>
+                <div class="request-portal-table-wrapper">
+                  <table class="data-grid-table request-portal-table">
+                    <thead>
+                      <tr>
+                        <th>Status</th>
+                        <th>Count</th>
+                        <th>Share</th>
+                      </tr>
+                    </thead>
+                    <tbody id="requestPortalMetricsStatusBody"></tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+
             <div class="form-row two-col">
               <div>
                 <label class="md-label" for="requestPortalFilterStatus">Status</label>
@@ -5207,6 +5282,10 @@
                 <button type="button" id="requestPortalFilterResetBtn" class="md-button md-button--outlined md-button--small">
                   <span class="material-symbols-rounded">restart_alt</span>
                   Reset
+                </button>
+                <button type="button" id="requestPortalExportCsvBtn" class="md-button md-button--outlined md-button--small">
+                  <span class="material-symbols-rounded">download</span>
+                  Export SLA CSV
                 </button>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Provide managers with actionable analytics about request fulfillment speed (avg/median turnaround, open aging, category/status breakdown) and let them export SLA datasets for analysis.

### Description
- Add backend timing normalization and new fields: compute `turnaroundMs` for closed requests, normalize legacy `requestedAt`/`closedAt` values, and keep `resolutionDurationHours` consistent.
- Implement manager-only metrics endpoints `GET /api/requests/metrics` (JSON summary with average/median turnarounds, open aging buckets, category and status breakdown) and `GET /api/requests/metrics/export.csv` (CSV export of SLA dataset), and integrate normalization into request read/update flows. 
- Include `turnaroundMs` in request responses and compute/update it when status transitions to `closed` or when normalizing the collection.
- Extend Request Portal manager view (`All Requests`) with KPI cards, a category SLA table, a status-slice table, an `Export SLA CSV` button, and frontend logic in `public/index.js` to fetch, render, refresh metrics and download CSVs.

### Testing
- Ran `npm test` and all tests passed (9 tests, 0 failures).
- Ran `node --check server.js` which reported no syntax errors.
- Ran `node --check public/index.js` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995f9918ae883329bbae082fe17e7cf)