### PR TITLE
Fix Request Portal persistence by syncing requests collection

### DIFF
--- a/db.js
+++ b/db.js
@@ -234,6 +234,7 @@ const db = {
       const [
         employees,
         applications,
+        requests,
         users,
         positions,
         candidates,
@@ -251,6 +252,7 @@ const db = {
       ] = await Promise.all([
         fetchCollection('employees'),
         fetchCollection('applications'),
+        fetchCollection('requests'),
         fetchCollection('users'),
         fetchCollection('positions'),
         fetchCollection('candidates'),
@@ -281,6 +283,7 @@ const db = {
       this.data = {
         employees,
         applications: leaveApplications,
+        requests,
         recruitmentApplications,
         users,
         positions,
@@ -315,6 +318,7 @@ const db = {
     const {
       employees = [],
       applications = [],
+      requests = [],
       recruitmentApplications = [],
       users = [],
       positions = [],
@@ -340,6 +344,7 @@ const db = {
     await Promise.all([
       syncCollection('employees', employees),
       syncCollection('applications', mergedApplications),
+      syncCollection('requests', requests),
       syncCollection('users', users),
       syncCollection('positions', positions),
       syncCollection('candidates', candidates),


### PR DESCRIPTION
### Motivation
- The Request Portal UI and server endpoints existed but request tickets were not persisted across process restarts because the `requests` collection was omitted from DB hydration and sync.
- Without persisting `requests` the end-to-end workflow appeared to work transiently but would lose data on cache refresh or restart, blocking true E2E behavior.

### Description
- Added `fetchCollection('requests')` to the DB read pipeline and included `requests` in `db.data` so in-memory state contains request tickets.
- Added `requests` to the destructured defaults in `db.write()` and added `syncCollection('requests', requests)` so `db.write()` persists requests back to the database.
- No API or UI changes were required because server endpoints and frontend wiring already existed; this change completes persistence for the existing Request Portal flow.

### Testing
- Ran `node --check db.js`, `node --check server.js`, and `node --check public/index.js` with no syntax errors reported (all passed).
- Ran `npm test` and the test suite passed (`9` tests, `0` failures).
- Note: an earlier automated attempt with an invalid test flag (`npm test -- --runInBand`) failed due to an unsupported Node option, but the correct `npm test` run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995e762723c833297c42500fe86a75a)