### PR TITLE
Request Portal: stack metrics and make New Request fields full-width

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -636,10 +636,33 @@
       gap: 20px;
     }
 
+    .request-portal-metrics-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+
     .learning-report-card {
       display: flex;
       flex-direction: column;
       gap: 16px;
+    }
+
+    .request-portal-form {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .request-portal-form-row {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .request-portal-form-row .md-textarea {
+      min-height: 140px;
     }
 
     .learning-report-card-header {
@@ -5116,13 +5139,13 @@
                   </div>
                 </div>
               </div>
-              <div class="form-row">
+              <div class="request-portal-form-row">
                 <label class="md-label" for="requestPortalSubject">Subject</label>
                 <input type="text" id="requestPortalSubject" class="md-input" maxlength="160" placeholder="Brief summary of your request" required>
               </div>
-              <div class="form-row">
+              <div class="request-portal-form-row">
                 <label class="md-label" for="requestPortalDetails">Request details</label>
-                <textarea id="requestPortalDetails" class="md-textarea" rows="4" placeholder="Share context, dates, and expected outcomes." required></textarea>
+                <textarea id="requestPortalDetails" class="md-textarea" rows="6" placeholder="Share context, dates, and expected outcomes." required></textarea>
               </div>
               <div class="form-actions">
                 <button type="submit" id="requestPortalSubmitBtn" class="md-button md-button--filled">
@@ -5203,7 +5226,7 @@
               </div>
             </div>
 
-            <div class="learning-report-grid" style="margin-bottom: 16px;">
+            <div class="request-portal-metrics-grid">
               <div class="md-card learning-report-card">
                 <div class="learning-report-card-header">
                   <h4>Category SLA breakdown</h4>


### PR DESCRIPTION
### Motivation
- Make the Request Portal metrics and New Request form follow a single-column layout so analytics cards don't appear side-by-side and form fields have full horizontal width for better readability.
- Ensure the New Request form presents `Subject` and `Request details` as separate full-width rows and give the details field more vertical space for multi-line input.

### Description
- Added CSS rules `.request-portal-metrics-grid`, `.request-portal-form`, and `.request-portal-form-row` and a textarea min-height to support stacked metrics and larger multi-line input. 
- Replaced the metrics container `learning-report-grid` with `request-portal-metrics-grid` so **Category SLA breakdown** and **Status slices** stack vertically. 
- Updated New Request markup to place `requestPortalSubject` and `requestPortalDetails` into their own `.request-portal-form-row` elements and increased `requestPortalDetails` to `rows="6"`. 
- Changes applied to `public/index.html` and committed.

### Testing
- Ran `npm test`, all automated tests passed (9/9).
- Served the site with `python3 -m http.server` and captured a Playwright screenshot of the updated UI, confirming the stacked metrics and expanded details area were rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69960308019883329a8d276e9e3c5564)