### PR TITLE
Refresh Request Portal categories after saving Request Categories settings

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -6075,6 +6075,7 @@ async function onRequestCategoriesSave() {
     requestCategoriesDirty = false;
     requestCategoriesLoaded = true;
     renderRequestCategories();
+    renderRequestPortalCategories(requestCategories);
     resetRequestCategoryForm();
     setRequestCategoriesStatus('Request categories saved successfully.', 'success');
   } catch (err) {


### PR DESCRIPTION
### Motivation
- Request categories added or edited in the Settings panel were not immediately visible in the Request Portal, requiring a page reload to see changes.
- The user experience should reflect saved settings immediately by updating the Request Portal category dropdown after a successful save.

### Description
- Immediately refresh the Request Portal category dropdown by calling `renderRequestPortalCategories(requestCategories)` after categories are saved in `onRequestCategoriesSave` in `public/index.js`.
- The change keeps the existing local state update and UI rendering of the settings list (`renderRequestCategories`) and then synchronizes the portal selector so no page reload is needed.
- The modification is localized to the frontend state synchronization logic in `public/index.js` and does not alter server endpoints.

### Testing
- Ran `node --check public/index.js` to validate the updated client script syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699605e27f4483329b3fd6541ee6b49b)