### PR TITLE
Move login visual CSS overrides into index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4787,6 +4787,83 @@
       color: #ffffff;
     }
 
+
+    /* Login card visual refinements scoped in-page */
+    .login-card {
+      position: relative;
+      background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 252, 0.9));
+      border: 1px solid rgba(148, 163, 184, 0.22);
+    }
+
+    .login-card::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: linear-gradient(145deg, rgba(58, 111, 248, 0.08), transparent 35%, rgba(103, 80, 164, 0.08));
+      pointer-events: none;
+    }
+
+    .login-card-header {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      gap: 12px;
+      text-align: center;
+    }
+
+    .brand-logo {
+      width: 118px;
+    }
+
+    .login-kicker {
+      margin: 0;
+      text-transform: uppercase;
+      letter-spacing: 0.13em;
+      font-size: 0.72rem;
+      font-weight: 800;
+      color: #334155;
+    }
+
+    .login-title {
+      font-weight: 750;
+    }
+
+    .login-security-strip {
+      display: flex;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .login-security-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      background: rgba(58, 111, 248, 0.09);
+      color: #1e40af;
+      font-size: 0.78rem;
+      font-weight: 700;
+    }
+
+    .login-security-item .material-symbols-rounded {
+      font-size: 1rem;
+    }
+
+    .form-stack {
+      position: relative;
+      z-index: 1;
+    }
+
+    .login-help-text {
+      margin: -4px 0 0;
+      text-align: center;
+      font-size: 0.82rem;
+      color: #475569;
+    }
+
   </style>
 </head>
 <body class="app-shell">
@@ -4821,10 +4898,17 @@
       </section>
 
       <div class="login-card">
-        <img id="loginBrandLogo" src="logo.png" alt="Organization logo" class="brand-logo">
-        <div>
-          <h1 id="loginPortalName" class="login-title">Brillar HR Portal</h1>
-          <p class="login-subtitle">Sign in to manage leave, approvals, performance cycles, and talent workflows with confidence.</p>
+        <div class="login-card-header">
+          <img id="loginBrandLogo" src="logo.png" alt="Organization logo" class="brand-logo">
+          <p class="login-kicker">Secure workforce access</p>
+          <div>
+            <h1 id="loginPortalName" class="login-title">Brillar HR Portal</h1>
+            <p class="login-subtitle">Sign in to manage leave, approvals, performance cycles, and talent workflows with confidence.</p>
+          </div>
+          <div class="login-security-strip" aria-hidden="true">
+            <span class="login-security-item"><span class="material-symbols-rounded">verified_user</span>Enterprise security</span>
+            <span class="login-security-item"><span class="material-symbols-rounded">encrypted</span>Encrypted sessions</span>
+          </div>
         </div>
         <form id="loginForm" class="form-stack">
           <div class="md-field">
@@ -4849,6 +4933,7 @@
             <span class="material-symbols-rounded">account_circle</span>
             Sign in with Microsoft 365
           </button>
+          <p class="login-help-text">Need help signing in? Contact your HR administrator or IT helpdesk.</p>
           <div id="loginError" class="form-error hidden"></div>
         </form>
       </div>


### PR DESCRIPTION
### Motivation
- Localize login-specific visual refinements into the page HTML so the CSS no longer leaks into the shared theme stylesheet.
- Preserve the previously added refined login markup, branding, and trust cues while honoring the request to keep CSS inside `index.html`.
- Reduce coupling between the global `material-theme.css` and page-scoped polish to make future tweaks safer.

### Description
- Moved the login visual CSS (card background, overlay gradient, header/kicker, security strip, help text, and `form-stack`/z-index rules) from `public/material-theme.css` into the inline `<style>` block in `public/index.html`.
- Reverted the corresponding login overrides from `public/material-theme.css` so that the shared stylesheet no longer contains login-specific rules and adjusted logo sizing in the theme file.
- Kept the enhanced login markup in `public/index.html` (added `login-card-header`, `login-kicker`, `login-security-strip` / `login-security-item`, and `.login-help-text`) while preserving all existing form IDs and inputs (`#loginForm`, `#loginEmail`, `#loginPassword`, `#msLoginBtn`, `#loginError`).

### Testing
- Ran `npm test` and all unit tests passed (9 tests, 0 failures).
- Started a static server with `python3 -m http.server 4173 --directory public` to validate the page served correctly.
- Attempted automated screenshot capture with Playwright, but the Chromium process crashed with a `SIGSEGV` in this environment so visual artifact generation failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699608160a588332942e93877ae30e14)