### PR TITLE
Replace deprecated OpenAI model defaults and add model_not_found fallback

### DIFF
--- a/aiSettings.js
+++ b/aiSettings.js
@@ -2,12 +2,13 @@ const { init, getDatabase } = require('./db');
 
 const AI_MODEL_OPTIONS = [
   { value: 'gpt-5', label: 'GPT5' },
-  { value: 'gpt-5.1-mini', label: 'GPT5.1 mini' },
-  { value: 'gpt-5.1-nano', label: 'GPT5.1nano' }
+  { value: 'gpt-5-mini', label: 'GPT5 mini' },
+  { value: 'gpt-5-nano', label: 'GPT5 nano' },
+  { value: 'gpt-4o-mini', label: 'GPT-4o mini' }
 ];
 
 const DEFAULT_AI_SETTINGS = {
-  model: 'gpt-5.1-mini',
+  model: 'gpt-5-mini',
   questionPrompt: `You are an HR expert. Generate a list of 5-8 thoughtful written interview questions for a candidate applying for the following position.
 
 Return ONLY a valid JSON array of objects with fields:
@@ -45,7 +46,12 @@ let aiSettingsCache = { value: null, loadedAt: 0 };
 
 function normalizeAiSettings(raw = {}) {
   const allowedValues = new Set(AI_MODEL_OPTIONS.map(option => option.value));
-  const model = allowedValues.has(raw.model) ? raw.model : DEFAULT_AI_SETTINGS.model;
+  const legacyModelAliases = {
+    'gpt-5.1-mini': 'gpt-5-mini',
+    'gpt-5.1-nano': 'gpt-5-nano'
+  };
+  const requestedModel = legacyModelAliases[raw.model] || raw.model;
+  const model = allowedValues.has(requestedModel) ? requestedModel : DEFAULT_AI_SETTINGS.model;
   const questionPrompt = typeof raw.questionPrompt === 'string' && raw.questionPrompt.trim()
     ? raw.questionPrompt.trim()
     : DEFAULT_AI_SETTINGS.questionPrompt;

--- a/server.js
+++ b/server.js
@@ -235,7 +235,7 @@ async function buildPerformanceCycleAiSummary({ cycleYear, employeeRows }) {
     ].join('\n');
 
     const completion = await client.chat.completions.create({
-      model: process.env.OPENAI_PERFORMANCE_REPORT_MODEL || 'gpt-5.1-mini',
+      model: process.env.OPENAI_PERFORMANCE_REPORT_MODEL || 'gpt-5-mini',
       messages: [
         { role: 'system', content: 'You are an HR analytics assistant. Respond with plain text only.' },
         { role: 'user', content: prompt }


### PR DESCRIPTION
### Motivation
- Production AI calls were failing with `model_not_found` 404s due to use of deprecated `gpt-5.1-*` model names, breaking interview question generation and other AI features. 
- Previously saved settings that referenced legacy model names should continue to work without manual migration. 
- Improve runtime resilience so a missing model triggers a safe fallback instead of a hard failure.

### Description
- Updated AI model options and default in `aiSettings.js` to use current model names (`gpt-5-mini`, `gpt-5-nano`, `gpt-4o-mini`) and changed the default model to `gpt-5-mini`.
- Added a `legacyModelAliases` mapping in `normalizeAiSettings` to transparently normalize old values like `gpt-5.1-mini` and `gpt-5.1-nano` to the new names.
- Implemented retry-on-missing-model in `createChatCompletionWithFallback` in `openaiClient.js` to catch `model_not_found` errors and retry with `OPENAI_FALLBACK_MODEL` (default `gpt-4o-mini`).
- Replaced hardcoded uses of `gpt-5.1-mini` with `gpt-5-mini` for interview question generation and interview response analysis in `openaiClient.js` and for performance summary generation in `server.js`.

### Testing
- Ran the project test suite with `npm test`, which completed successfully with all tests passing (`# pass 10`, `# fail 0`).
- No automated tests were added for the fallback behavior; runtime code paths will use `OPENAI_FALLBACK_MODEL` when a model is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6996e444b0548332a4c924bce1c50069)