### PR TITLE
Persist AI interview mode and add voice/orchestration defaults

### DIFF
--- a/api/publicAiInterview.js
+++ b/api/publicAiInterview.js
@@ -45,6 +45,33 @@ function mapQuestions(questions) {
   }));
 }
 
+function normalizeSessionMode(mode) {
+  return mode === 'voice' ? 'voice' : 'text';
+}
+
+function buildVoiceDefaults(voice) {
+  return {
+    startedAt: voice?.startedAt || null,
+    endedAt: voice?.endedAt || null,
+    durationSec: Number.isFinite(voice?.durationSec) ? voice.durationSec : null,
+    transcriptTurns: Array.isArray(voice?.transcriptTurns) ? voice.transcriptTurns : [],
+    artifacts: voice?.artifacts || null
+  };
+}
+
+function buildOrchestrationDefaults(orchestration) {
+  return {
+    rubricVersion: orchestration?.rubricVersion || null,
+    interviewPlan: Array.isArray(orchestration?.interviewPlan) ? orchestration.interviewPlan : [],
+    coverage:
+      orchestration?.coverage && typeof orchestration.coverage === 'object'
+        ? orchestration.coverage
+        : {},
+    lastQuestionId: orchestration?.lastQuestionId || null,
+    difficulty: orchestration?.difficulty || null
+  };
+}
+
 function buildRecruiterNotificationLines({ candidateName, positionTitle, candidateEmail, result }) {
   const lines = [
     'Hi team,',
@@ -119,6 +146,9 @@ router.get('/ai-interview/:token', async (req, res) => {
 
     return res.json({
       status: session.status || 'pending',
+      mode: normalizeSessionMode(session.mode),
+      voice: buildVoiceDefaults(session.voice),
+      orchestration: buildOrchestrationDefaults(session.orchestration),
       candidateName,
       positionTitle,
       templateTitle,


### PR DESCRIPTION
### Motivation
- Ensure sessions explicitly record interview `mode` (defaulting to `"text"`) so voice-enabled interviews are tracked reliably.
- Provide stable, mode-safe `voice` and `orchestration` fields on new sessions and normalize missing nested data when reading legacy sessions.

### Description
- Added `normalizeSessionMode`, `buildVoiceDefaults`, and `buildOrchestrationDefaults` helpers to `api/hrAiInterview.js` and `api/publicAiInterview.js` to canonicalize `mode` and nested objects.
- `POST /api/hr/ai-interview/sessions` now accepts an optional `mode` and persists a normalized `mode` plus default-initialized `voice` and `orchestration` objects on new `ai_interview_sessions` documents.
- Readers `GET /api/hr/ai-interview/application/:applicationId` and `GET /api/ai-interview/:token` now return `mode`, `voice`, and `orchestration` with safe defaults so older documents are treated as `mode: "text"` and missing nested fields become null/empty values.

### Testing
- Ran `node --check api/hrAiInterview.js` and `node --check api/publicAiInterview.js`, both succeeded.
- Attempted to `require` both modules in a single `node -e` invocation, which failed due to a missing `OPENAI_API_KEY` in the environment rather than a syntax error in the changed files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699820bd4ec48332bb50a40274138ff2)