### PR TITLE
Add public AI voice interview endpoints with realtime session support

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,6 +42,7 @@ const hrAiInterviewRoutes = require('./api/hrAiInterview');
 const hrApplicationsRoutes = require('./api/hrApplications');
 const publicCareersRoutes = require('./api/publicCareers');
 const publicAiInterviewRoutes = require('./api/publicAiInterview');
+const publicAiVoiceInterviewRoutes = require('./api/publicAiVoiceInterview');
 const learningHubRoutes = require('./api/learningHub');
 const adminRolesRoutes = require('./api/adminRoles');
 const {
@@ -2958,6 +2959,7 @@ app.use('/api/hr', hrAiInterviewRoutes);
 app.use('/api/hr', hrApplicationsRoutes);
 app.use('/api/public', publicCareersRoutes);
 app.use('/api/public', publicAiInterviewRoutes);
+app.use('/api/public', publicAiVoiceInterviewRoutes);
 app.use('/api/learning-hub', authRequired, learningHubRoutes);
 app.use('/api/admin-roles', authRequired, superadminOnly, adminRolesRoutes);
 


### PR DESCRIPTION
### Motivation
- Provide a public-facing API to run AI-powered voice interviews and integrate ephemeral realtime credentials for browser clients. 
- Ensure voice sessions are constrained to sessions created for `mode === "voice"` and avoid exposing long-lived API keys. 
- Persist finalized transcript turns, mark interview lifecycle events, and queue scoped final analysis with recruiter notification. 

### Description
- Added a new router `api/publicAiVoiceInterview.js` implementing `GET /ai-voice-interview/:token`, `POST /ai-voice-interview/:token/realtime-session`, `POST /ai-voice-interview/:token/transcript`, and `POST /ai-voice-interview/:token/complete`. 
- `GET /ai-voice-interview/:token` validates session existence and that `mode === "voice"`, then returns session `status`, `candidateName`/`candidateEmail`, `positionTitle`/`templateTitle`, and a `realtimeConfig` object. 
- `POST /ai-voice-interview/:token/realtime-session` rejects completed sessions, enforces token+IP in-memory rate limiting, and mints server-issued ephemeral realtime credentials by calling OpenAI realtime sessions (does not expose long-lived keys). 
- `POST /ai-voice-interview/:token/transcript` accepts finalized turns, normalizes and appends them into `voice.transcriptTurns`, and sets `status='started'` and `voice.startedAt` on the first appended turn. 
- `POST /ai-voice-interview/:token/complete` performs an idempotent completion write (`status`, `completedAt`, `voice.endedAt`, `voice.durationSec`, `analysisStatus`), then enqueues final analysis and recruiter notification scoped to the session. 
- Shared helpers include stable error codes (`session_not_found`, `session_mode_mismatch`, `session_already_completed`, `realtime_session_rate_limited`, etc.), transcript normalization, in-memory rate limiter, and async analysis queuing that reuses `analyzeInterviewResponses`. 
- Mounted the router in `server.js` under the existing public API namespace at `/api/public`.

### Testing
- Ran unit tests with `node --test` and all existing tests passed (`10/10` passing). 
- Attempted to `require('./api/publicAiVoiceInterview')` to validate module load; this fails in the current environment when `OPENAI_API_KEY` is not set because OpenAI client initialization is triggered on import (observed error: missing `OPENAI_API_KEY`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6998282051b083329a5c4d1a89ef1d22)