### PR TITLE
Add AI voice interview public page and WebRTC client flow

### DIFF
--- a/public/ai-voice-interview.html
+++ b/public/ai-voice-interview.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>HR Connect AI Voice Interview</title>
+  <link rel="icon" href="/logo.png" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 text-slate-900">
+  <header class="sticky top-0 z-20 bg-white/95 backdrop-blur border-b border-slate-200">
+    <nav class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <img id="brandLogo" src="/logo.png" alt="Organization logo" class="h-10 w-auto" />
+        <p id="brandName" class="font-semibold">HR Connect</p>
+      </div>
+      <a href="/careers" class="text-sm font-medium text-blue-600 hover:text-blue-700">Careers</a>
+    </nav>
+  </header>
+
+  <main class="max-w-5xl mx-auto px-6 py-10 space-y-6">
+    <section class="rounded-2xl bg-gradient-to-r from-blue-900 to-indigo-600 text-white p-6 sm:p-8 shadow-lg">
+      <p class="uppercase tracking-wider text-xs text-blue-200">AI Voice Interview</p>
+      <h1 class="text-3xl sm:text-4xl font-bold mt-2">Interview with Voice</h1>
+      <p id="heroCopy" class="mt-3 text-blue-100">Allow microphone access, then start when you're ready. Your responses are transcribed and submitted automatically.</p>
+    </section>
+
+    <section id="appRoot" class="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 sm:p-8">
+      <p class="text-slate-600">Loading interview…</p>
+    </section>
+  </main>
+
+  <audio id="remoteAudio" autoplay></audio>
+  <script src="/ai-voice-interview.js" defer></script>
+</body>
+</html>

--- a/public/ai-voice-interview.js
+++ b/public/ai-voice-interview.js
@@ -1,0 +1,351 @@
+(function () {
+  const root = document.getElementById('appRoot');
+  const remoteAudio = document.getElementById('remoteAudio');
+  const token = window.location.pathname.split('/').pop();
+
+  const state = {
+    metadata: null,
+    stream: null,
+    pc: null,
+    channel: null,
+    connected: false,
+    muted: false,
+    transcriptVisible: false,
+    status: 'idle',
+    transcriptTurns: [],
+    completeSent: false,
+    disconnectTimer: null
+  };
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function setStatus(status, detail) {
+    state.status = status;
+    const statusEl = document.getElementById('statusText');
+    const detailEl = document.getElementById('statusDetail');
+    if (statusEl) {
+      statusEl.textContent = status;
+      statusEl.className = 'text-sm font-semibold ' + (
+        status === 'speaking' ? 'text-violet-700' : status === 'listening' ? 'text-emerald-700' : 'text-blue-700'
+      );
+    }
+    if (detailEl) {
+      detailEl.textContent = detail || '';
+    }
+  }
+
+  function renderTranscript() {
+    const panel = document.getElementById('transcriptPanel');
+    if (!panel) return;
+
+    if (!state.transcriptVisible) {
+      panel.classList.add('hidden');
+      return;
+    }
+
+    panel.classList.remove('hidden');
+    panel.innerHTML = state.transcriptTurns.length
+      ? state.transcriptTurns
+          .map(turn => `
+            <div class="border border-slate-200 rounded-lg p-3">
+              <p class="text-xs uppercase tracking-wide text-slate-500">${escapeHtml(turn.role || 'candidate')}</p>
+              <p class="text-sm text-slate-800 mt-1">${escapeHtml(turn.text)}</p>
+            </div>
+          `)
+          .join('')
+      : '<p class="text-sm text-slate-500">Transcript will appear here once speech is captured.</p>';
+  }
+
+  function renderApp() {
+    const candidateName = state.metadata?.candidateName || 'Candidate';
+    const positionTitle = state.metadata?.positionTitle || 'this role';
+    root.innerHTML = `
+      <div class="space-y-6">
+        <div>
+          <h2 class="text-2xl font-semibold">Welcome, ${escapeHtml(candidateName)}</h2>
+          <p class="text-slate-600 mt-2">You are interviewing for <span class="font-medium">${escapeHtml(positionTitle)}</span>.</p>
+        </div>
+
+        <div class="rounded-xl border border-blue-100 bg-blue-50 p-4 space-y-1">
+          <p class="text-xs uppercase tracking-wide text-blue-700">Interview state</p>
+          <p id="statusText" class="text-sm font-semibold text-blue-700">idle</p>
+          <p id="statusDetail" class="text-sm text-blue-800">Grant microphone permission, then click start.</p>
+        </div>
+
+        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <button id="startBtn" class="px-4 py-3 rounded-lg bg-blue-600 text-white font-semibold hover:bg-blue-700">Enable mic & start</button>
+          <button id="muteBtn" class="px-4 py-3 rounded-lg bg-slate-100 text-slate-800 font-semibold border border-slate-300 disabled:opacity-50" disabled>Mute</button>
+          <button id="repeatBtn" class="px-4 py-3 rounded-lg bg-slate-100 text-slate-800 font-semibold border border-slate-300 disabled:opacity-50" disabled>Repeat question</button>
+          <button id="toggleTranscriptBtn" class="px-4 py-3 rounded-lg bg-slate-100 text-slate-800 font-semibold border border-slate-300">Show transcript</button>
+          <button id="endBtn" class="px-4 py-3 rounded-lg bg-rose-600 text-white font-semibold hover:bg-rose-700 disabled:opacity-50" disabled>End interview</button>
+          <a href="/ai-interview/${encodeURIComponent(token)}" class="px-4 py-3 rounded-lg bg-white text-slate-800 font-semibold border border-slate-300 text-center">Switch to text</a>
+        </div>
+
+        <div id="transcriptPanel" class="hidden rounded-xl border border-slate-200 p-4 space-y-3"></div>
+      </div>
+    `;
+
+    document.getElementById('startBtn').addEventListener('click', startVoiceInterview);
+    document.getElementById('muteBtn').addEventListener('click', toggleMute);
+    document.getElementById('repeatBtn').addEventListener('click', repeatQuestion);
+    document.getElementById('toggleTranscriptBtn').addEventListener('click', () => {
+      state.transcriptVisible = !state.transcriptVisible;
+      document.getElementById('toggleTranscriptBtn').textContent = state.transcriptVisible
+        ? 'Hide transcript'
+        : 'Show transcript';
+      renderTranscript();
+    });
+    document.getElementById('endBtn').addEventListener('click', async () => {
+      await completeInterview('manual_end');
+      teardownConnection();
+      setStatus('completed', 'Interview ended. Thank you.');
+    });
+
+    renderTranscript();
+  }
+
+  async function fetchMetadata() {
+    const response = await fetch(`/api/public/ai-voice-interview/${encodeURIComponent(token)}`);
+    if (!response.ok) throw new Error('failed_to_fetch_metadata');
+    return response.json();
+  }
+
+  async function requestRealtimeSession() {
+    const response = await fetch(`/api/public/ai-voice-interview/${encodeURIComponent(token)}/realtime-session`, {
+      method: 'POST'
+    });
+
+    if (!response.ok) throw new Error('failed_to_fetch_realtime_session');
+    return response.json();
+  }
+
+  async function sendTranscriptChunk(turn) {
+    if (!turn?.text) return;
+    await fetch(`/api/public/ai-voice-interview/${encodeURIComponent(token)}/transcript`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ turns: [turn] })
+    });
+  }
+
+  async function completeInterview(reason) {
+    if (state.completeSent) return;
+    state.completeSent = true;
+
+    try {
+      await fetch(`/api/public/ai-voice-interview/${encodeURIComponent(token)}/complete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: reason || 'unknown' })
+      });
+    } catch (err) {
+      console.error('Failed to mark interview complete', err);
+    }
+  }
+
+  async function startVoiceInterview() {
+    const startBtn = document.getElementById('startBtn');
+    const muteBtn = document.getElementById('muteBtn');
+    const repeatBtn = document.getElementById('repeatBtn');
+    const endBtn = document.getElementById('endBtn');
+
+    try {
+      startBtn.disabled = true;
+      setStatus('connecting', 'Requesting microphone permission...');
+      state.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+
+      setStatus('connecting', 'Creating secure voice session...');
+      const realtime = await requestRealtimeSession();
+      const ephemeralKey = realtime?.client_secret?.value;
+      const model = realtime?.session?.model || state.metadata?.realtimeConfig?.model || 'gpt-4o-realtime-preview-2024-12-17';
+
+      if (!ephemeralKey) {
+        throw new Error('missing_client_secret');
+      }
+
+      const pc = new RTCPeerConnection();
+      state.pc = pc;
+      state.stream.getTracks().forEach(track => pc.addTrack(track, state.stream));
+
+      pc.ontrack = event => {
+        remoteAudio.srcObject = event.streams[0];
+      };
+
+      pc.onconnectionstatechange = () => {
+        const status = pc.connectionState;
+        if (status === 'connected') {
+          state.connected = true;
+          setStatus('listening', 'Connected. Speak naturally when prompted.');
+          clearTimeout(state.disconnectTimer);
+        } else if (status === 'disconnected' || status === 'failed' || status === 'closed') {
+          setStatus('connecting', 'Connection lost. Wrapping up...');
+          clearTimeout(state.disconnectTimer);
+          state.disconnectTimer = setTimeout(async () => {
+            await completeInterview('disconnect_timeout');
+          }, 6000);
+        }
+      };
+
+      const channel = pc.createDataChannel('oai-events');
+      state.channel = channel;
+
+      channel.addEventListener('open', () => {
+        setStatus('listening', 'Listening for your response...');
+        channel.send(JSON.stringify({ type: 'response.create' }));
+      });
+
+      channel.addEventListener('message', async event => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === 'output_audio_buffer.started') {
+            setStatus('speaking', 'Interviewer is speaking...');
+          }
+
+          if (data.type === 'output_audio_buffer.stopped') {
+            setStatus('listening', 'Your turn to answer.');
+          }
+
+          if (data.type === 'conversation.item.input_audio_transcription.completed') {
+            const text = typeof data.transcript === 'string' ? data.transcript.trim() : '';
+            if (!text) return;
+
+            const turn = {
+              id: data.item_id || `turn_${Date.now()}`,
+              role: 'candidate',
+              text,
+              finalized: true,
+              timestamp: new Date().toISOString()
+            };
+
+            state.transcriptTurns.push(turn);
+            renderTranscript();
+            await sendTranscriptChunk(turn);
+          }
+        } catch (err) {
+          console.error('Failed to parse realtime event', err);
+        }
+      });
+
+      const offer = await pc.createOffer({ offerToReceiveAudio: true });
+      await pc.setLocalDescription(offer);
+
+      const sdpResponse = await fetch(`https://api.openai.com/v1/realtime?model=${encodeURIComponent(model)}`, {
+        method: 'POST',
+        body: offer.sdp,
+        headers: {
+          Authorization: `Bearer ${ephemeralKey}`,
+          'Content-Type': 'application/sdp'
+        }
+      });
+
+      if (!sdpResponse.ok) {
+        throw new Error('failed_to_negotiate_webrtc');
+      }
+
+      const answerSdp = await sdpResponse.text();
+      await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp });
+
+      muteBtn.disabled = false;
+      repeatBtn.disabled = false;
+      endBtn.disabled = false;
+      setStatus('listening', 'Connected. Start speaking when ready.');
+    } catch (err) {
+      console.error('Failed to start voice interview', err);
+      setStatus('error', 'Unable to start voice interview. Please refresh and try again.');
+      startBtn.disabled = false;
+    }
+  }
+
+  function toggleMute() {
+    if (!state.stream) return;
+    state.muted = !state.muted;
+    state.stream.getAudioTracks().forEach(track => {
+      track.enabled = !state.muted;
+    });
+
+    const muteBtn = document.getElementById('muteBtn');
+    if (muteBtn) {
+      muteBtn.textContent = state.muted ? 'Unmute' : 'Mute';
+    }
+  }
+
+  function repeatQuestion() {
+    if (!state.channel || state.channel.readyState !== 'open') return;
+    state.channel.send(
+      JSON.stringify({
+        type: 'response.create',
+        response: {
+          instructions: 'Please repeat the previous interview question exactly once.'
+        }
+      })
+    );
+    setStatus('speaking', 'Asking interviewer to repeat the question...');
+  }
+
+  function teardownConnection() {
+    if (state.channel && state.channel.readyState === 'open') {
+      state.channel.close();
+    }
+
+    if (state.pc) {
+      state.pc.close();
+    }
+
+    if (state.stream) {
+      state.stream.getTracks().forEach(track => track.stop());
+    }
+  }
+
+  async function applyBranding() {
+    try {
+      const response = await fetch('/public/settings/organization');
+      if (!response.ok) return;
+      const settings = await response.json();
+      const name = settings?.portalName || 'HR Connect';
+      const logo = settings?.logoUrl || '/logo.png';
+      const logoEl = document.getElementById('brandLogo');
+      const nameEl = document.getElementById('brandName');
+      if (logoEl) logoEl.src = logo;
+      if (nameEl) nameEl.textContent = name;
+      document.title = `${name} AI Voice Interview`;
+    } catch (err) {
+      // no-op
+    }
+  }
+
+  async function init() {
+    await applyBranding();
+
+    if (!token) {
+      root.innerHTML = '<p class="text-red-700">Invalid interview link.</p>';
+      return;
+    }
+
+    try {
+      state.metadata = await fetchMetadata();
+      if (state.metadata?.status === 'completed') {
+        root.innerHTML = '<p class="text-slate-700">This interview has already been completed. Thank you.</p>';
+        return;
+      }
+      renderApp();
+    } catch (err) {
+      root.innerHTML = '<p class="text-red-700">Unable to load interview details. Please retry later.</p>';
+    }
+  }
+
+  window.addEventListener('beforeunload', () => {
+    if (state.connected && !state.completeSent) {
+      completeInterview('page_unload');
+    }
+    teardownConnection();
+  });
+
+  init();
+})();

--- a/server.js
+++ b/server.js
@@ -2971,6 +2971,10 @@ app.get('/ai-interview/:token', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'ai-interview.html'));
 });
 
+app.get('/ai-voice-interview/:token', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'ai-voice-interview.html'));
+});
+
 function resolveToken(req) {
   const headerToken = req.headers.authorization?.split(' ')[1];
   const cookieToken = req.cookies?.[SESSION_COOKIE_NAME];


### PR DESCRIPTION
### Motivation
- Provide a voice-based interview landing and in-browser WebRTC client so candidates can complete AI-assisted voice interviews with live audio, transcription, and automatic submission.
- Use ephemeral realtime sessions (OpenAI Realtime) and finalized transcript streaming to persist candidate responses and trigger analysis on completion.

### Description
- Add `public/ai-voice-interview.html` as the landing page and mount point for the voice interview UI with branding placeholders and an audio element.
- Add `public/ai-voice-interview.js` implementing client behavior to parse the token from the URL, fetch landing metadata (`GET /api/public/ai-voice-interview/:token`), request ephemeral realtime credentials (`POST /api/public/ai-voice-interview/:token/realtime-session`), perform WebRTC negotiation against OpenAI Realtime, handle data-channel events and audio playback, stream finalized transcript turns to `/api/public/ai-voice-interview/:token/transcript`, and call `/api/public/ai-voice-interview/:token/complete` on manual end, disconnect timeout, or page unload; it also exposes UI controls for mic/start, connection/listening/speaking state, transcript toggle, mute/unmute, repeat question, end interview, and a `Switch to text` fallback link.
- Wire the page into the server by adding `app.get('/ai-voice-interview/:token', ...)` in `server.js` to serve the new HTML.

### Testing
- Ran `node --check public/ai-voice-interview.js` and it passed syntax checks.
- Ran `node --check server.js` and it passed syntax checks.
- Ran the repository`s test suite with `npm test` which completed successfully (all 10 tests passed).
- Attempted an automated Playwright page capture to `http://127.0.0.1:3000/ai-voice-interview/demo-token`, but the capture failed with `ERR_EMPTY_RESPONSE` due to local runtime service dependencies (MongoDB/OpenAI config) not being available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6998290cb8248332857c8e3612ad35e6)