### PR TITLE
Add Option-B voice interview orchestration and scoring services

### DIFF
--- a/services/aiVoiceInterviewOrchestrator.js
+++ b/services/aiVoiceInterviewOrchestrator.js
@@ -1,0 +1,129 @@
+const {
+  SCORING_VERSION,
+  RUBRIC_VERSION,
+  inferCompetency,
+  buildCoverageUpdate,
+  scoreAnswer
+} = require('./aiVoiceInterviewScoring');
+
+function toDate(input) {
+  if (!input) return null;
+  const value = input instanceof Date ? input : new Date(input);
+  return Number.isNaN(value.getTime()) ? null : value;
+}
+
+function buildInitialOrchestration(session) {
+  const existing = session?.orchestration && typeof session.orchestration === 'object'
+    ? session.orchestration
+    : {};
+
+  return {
+    phase: existing.phase || 'intro',
+    startedAt: existing.startedAt || session?.voice?.startedAt || session?.startedAt || null,
+    endedAt: existing.endedAt || null,
+    durationSec: Number.isFinite(existing.durationSec) ? existing.durationSec : null,
+    rubricVersion: existing.rubricVersion || RUBRIC_VERSION,
+    scoringVersion: existing.scoringVersion || SCORING_VERSION,
+    coverage: existing.coverage && typeof existing.coverage === 'object' ? existing.coverage : {},
+    difficulty: existing.difficulty || 'medium',
+    evidenceCandidates: Array.isArray(existing.evidenceCandidates) ? existing.evidenceCandidates : [],
+    turnAssessments: Array.isArray(existing.turnAssessments) ? existing.turnAssessments : [],
+    askedQuestionIds: Array.isArray(existing.askedQuestionIds) ? existing.askedQuestionIds : [],
+    lastQuestionId: existing.lastQuestionId || null
+  };
+}
+
+function score_answer({ session, turn }) {
+  const orchestration = buildInitialOrchestration(session);
+  const questions = Array.isArray(session?.aiInterviewQuestions) ? session.aiInterviewQuestions : [];
+  const askedCount = orchestration.turnAssessments.length;
+  const currentQuestion = questions[askedCount] || null;
+  const questionId = currentQuestion?.id || currentQuestion?.questionId || currentQuestion?._id?.toString?.() || null;
+  const competency = inferCompetency(currentQuestion);
+
+  const assessment = scoreAnswer({
+    answerText: turn?.text || '',
+    competency,
+    turnId: turn?.id || null,
+    questionId,
+    difficulty: orchestration.difficulty
+  });
+
+  const updatedCoverage = buildCoverageUpdate(orchestration.coverage, competency, assessment.score);
+  const evidenceCandidates = assessment.evidenceCandidate?.quote
+    ? [...orchestration.evidenceCandidates, assessment.evidenceCandidate].slice(-12)
+    : orchestration.evidenceCandidates;
+
+  return {
+    ...orchestration,
+    phase: 'questioning',
+    coverage: updatedCoverage,
+    difficulty: assessment.difficultyAfter,
+    evidenceCandidates,
+    turnAssessments: [...orchestration.turnAssessments, assessment],
+    askedQuestionIds: questionId && !orchestration.askedQuestionIds.includes(questionId)
+      ? [...orchestration.askedQuestionIds, questionId]
+      : orchestration.askedQuestionIds,
+    lastQuestionId: questionId || orchestration.lastQuestionId
+  };
+}
+
+function next_question({ session }) {
+  const orchestration = buildInitialOrchestration(session);
+  const questions = Array.isArray(session?.aiInterviewQuestions) ? session.aiInterviewQuestions : [];
+  const asked = new Set(orchestration.askedQuestionIds || []);
+
+  const next = questions.find((question, index) => {
+    const questionId = question?.id || question?.questionId || question?._id?.toString?.() || `q${index + 1}`;
+    return !asked.has(questionId);
+  }) || null;
+
+  if (!next) {
+    return {
+      question: null,
+      orchestration: {
+        ...orchestration,
+        phase: 'closing'
+      }
+    };
+  }
+
+  const questionId = next?.id || next?.questionId || next?._id?.toString?.() || null;
+
+  return {
+    question: {
+      id: questionId,
+      text: next?.text || next?.question || '',
+      competency: inferCompetency(next)
+    },
+    orchestration: {
+      ...orchestration,
+      phase: 'questioning',
+      lastQuestionId: questionId || orchestration.lastQuestionId
+    }
+  };
+}
+
+function finalizeOrchestration({ session, endedAt }) {
+  const orchestration = buildInitialOrchestration(session);
+  const startedAt = toDate(orchestration.startedAt || session?.voice?.startedAt || session?.startedAt);
+  const ended = toDate(endedAt) || new Date();
+  const durationSec = startedAt
+    ? Math.max(0, Math.round((ended.getTime() - startedAt.getTime()) / 1000))
+    : 0;
+
+  return {
+    ...orchestration,
+    phase: 'completed',
+    startedAt: startedAt || ended,
+    endedAt: ended,
+    durationSec
+  };
+}
+
+module.exports = {
+  score_answer,
+  next_question,
+  buildInitialOrchestration,
+  finalizeOrchestration
+};

--- a/services/aiVoiceInterviewScoring.js
+++ b/services/aiVoiceInterviewScoring.js
@@ -1,0 +1,145 @@
+const SCORING_VERSION = 'voice-option-b-v1';
+const RUBRIC_VERSION = 'voice-rubric-v1';
+
+function clampScore(value, min = 1, max = 5) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function quoteFromAnswer(answerText) {
+  const normalized = normalizeText(answerText).replace(/\s+/g, ' ');
+  if (!normalized) return '';
+  return normalized.length > 220 ? `${normalized.slice(0, 217)}...` : normalized;
+}
+
+function inferCompetency(question) {
+  if (!question || typeof question !== 'object') return 'general';
+  return (
+    question.competency ||
+    question.category ||
+    question.topic ||
+    question.dimension ||
+    'general'
+  );
+}
+
+function buildCoverageUpdate(currentCoverage, competency, score) {
+  const existing = currentCoverage?.[competency] || {
+    answerCount: 0,
+    totalScore: 0,
+    averageScore: 0,
+    latestScore: null
+  };
+
+  const answerCount = existing.answerCount + 1;
+  const totalScore = existing.totalScore + score;
+
+  return {
+    ...currentCoverage,
+    [competency]: {
+      answerCount,
+      totalScore,
+      averageScore: Number((totalScore / answerCount).toFixed(2)),
+      latestScore: score
+    }
+  };
+}
+
+function pickDifficulty(currentDifficulty, score) {
+  if (score >= 4) return 'hard';
+  if (score <= 2) return 'easy';
+  return currentDifficulty || 'medium';
+}
+
+function scoreAnswer({ answerText, competency, turnId, questionId, difficulty }) {
+  const normalizedAnswer = normalizeText(answerText);
+  const wordCount = normalizedAnswer ? normalizedAnswer.split(/\s+/).length : 0;
+
+  let baseScore = 1;
+  if (wordCount >= 15) baseScore += 1;
+  if (wordCount >= 35) baseScore += 1;
+  if (wordCount >= 60) baseScore += 1;
+  if (/\b(example|because|result|impact|improved|delivered|learned)\b/i.test(normalizedAnswer)) {
+    baseScore += 1;
+  }
+
+  const finalScore = clampScore(baseScore);
+
+  return {
+    score: finalScore,
+    competency: competency || 'general',
+    questionId: questionId || null,
+    turnId: turnId || null,
+    assessedAt: new Date(),
+    difficultyAfter: pickDifficulty(difficulty, finalScore),
+    evidenceCandidate: {
+      quote: quoteFromAnswer(normalizedAnswer),
+      turnId: turnId || null,
+      competency: competency || 'general',
+      questionId: questionId || null,
+      score: finalScore
+    }
+  };
+}
+
+function buildVoiceResult({ session, candidateId, applicationId, positionId }) {
+  const orchestration = session?.orchestration || {};
+  const coverage = orchestration.coverage || {};
+  const competencyKeys = Object.keys(coverage);
+  const competencyAverages = competencyKeys
+    .map(key => Number(coverage[key]?.averageScore || 0))
+    .filter(value => Number.isFinite(value) && value > 0);
+
+  const overall = competencyAverages.length
+    ? Number((competencyAverages.reduce((sum, value) => sum + value, 0) / competencyAverages.length).toFixed(2))
+    : 0;
+
+  const verdict = overall >= 4 ? 'proceed' : overall >= 3 ? 'hold' : 'reject';
+  const evidence = Array.isArray(orchestration.evidenceCandidates)
+    ? orchestration.evidenceCandidates.filter(item => item?.quote)
+    : [];
+
+  return {
+    sessionId: session._id,
+    applicationId,
+    candidateId,
+    positionId,
+    mode: 'voice',
+    scores: {
+      overall,
+      communication: coverage.communication?.averageScore ?? null,
+      technical: coverage.technical?.averageScore ?? null,
+      cultureFit: coverage['culture-fit']?.averageScore ?? coverage.cultureFit?.averageScore ?? null
+    },
+    verdict,
+    summary: `Voice interview completed with ${evidence.length} evidence snippet(s).`,
+    strengths: competencyKeys.filter(key => (coverage[key]?.averageScore || 0) >= 4),
+    risks: competencyKeys.filter(key => (coverage[key]?.averageScore || 0) <= 2.5),
+    recommendedNextSteps: ['Review evidence snippets before advancing candidate.'],
+    evidence,
+    timeline: {
+      startedAt: orchestration.startedAt || session.voice?.startedAt || session.startedAt || null,
+      endedAt: orchestration.endedAt || session.voice?.endedAt || session.completedAt || null,
+      durationSec: Number.isFinite(orchestration.durationSec)
+        ? orchestration.durationSec
+        : session.voice?.durationSec ?? null
+    },
+    scoringVersion: orchestration.scoringVersion || SCORING_VERSION,
+    rubricVersion: orchestration.rubricVersion || RUBRIC_VERSION,
+    rawModelResponse: null,
+    createdAt: new Date()
+  };
+}
+
+module.exports = {
+  SCORING_VERSION,
+  RUBRIC_VERSION,
+  inferCompetency,
+  buildCoverageUpdate,
+  scoreAnswer,
+  buildVoiceResult
+};


### PR DESCRIPTION
### Motivation

- Implement an Option-B flow for AI voice interviews that keeps orchestration state on the session and enables per-turn automated scoring.
- Capture coverage, difficulty progression and evidence candidates as the interview proceeds so final results can be consolidated for recruiters. 
- Keep the existing written (`mode: "text"`) scoring path untouched while extending voice-specific processing.

### Description

- Added `services/aiVoiceInterviewOrchestrator.js` which maintains `session.orchestration` state and exposes `score_answer(...)`, `next_question(...)`, `buildInitialOrchestration(...)`, and `finalizeOrchestration(...)` tool-contract functions.
- Added `services/aiVoiceInterviewScoring.js` which implements per-answer scoring, coverage updates, difficulty picking, evidence candidate generation, and `buildVoiceResult(...)` to produce the final `ai_interview_results` payload with `mode: "voice"`, `evidence[]`, `timeline`, `scoringVersion`, and `rubricVersion`.
- Updated `api/publicAiVoiceInterview.js` to apply `score_answer` on incoming candidate transcript turns, persist `orchestration` updates on the session, return orchestration and `nextQuestion` contract data from the transcript endpoint, finalize orchestration on completion, and write the consolidated voice-mode result into the `ai_interview_results` collection while preserving recruiter notification behavior.

### Testing

- Ran `npm test` which completed successfully (TAP output showing 10 passing tests). 
- Attempted `npm test -- --runInBand` which failed due to a Node option mismatch (reported `node: bad option: --runInBand`).
- Performed syntax checks with `node --check api/publicAiVoiceInterview.js services/aiVoiceInterviewOrchestrator.js services/aiVoiceInterviewScoring.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69982ad380388332ac2eaa89c57f2504)