### PR TITLE
Harden public AI voice interview session endpoints

### DIFF
--- a/services/aiVoiceInterviewOrchestrator.js
+++ b/services/aiVoiceInterviewOrchestrator.js
@@ -6,6 +6,8 @@ const {
   scoreAnswer
 } = require('./aiVoiceInterviewScoring');
 
+const PROMPT_VERSION = process.env.PUBLIC_AI_VOICE_PROMPT_VERSION || 'voice-prompt-v1';
+
 function toDate(input) {
   if (!input) return null;
   const value = input instanceof Date ? input : new Date(input);
@@ -22,6 +24,7 @@ function buildInitialOrchestration(session) {
     startedAt: existing.startedAt || session?.voice?.startedAt || session?.startedAt || null,
     endedAt: existing.endedAt || null,
     durationSec: Number.isFinite(existing.durationSec) ? existing.durationSec : null,
+    promptVersion: existing.promptVersion || PROMPT_VERSION,
     rubricVersion: existing.rubricVersion || RUBRIC_VERSION,
     scoringVersion: existing.scoringVersion || SCORING_VERSION,
     coverage: existing.coverage && typeof existing.coverage === 'object' ? existing.coverage : {},

--- a/services/aiVoiceInterviewScoring.js
+++ b/services/aiVoiceInterviewScoring.js
@@ -128,6 +128,7 @@ function buildVoiceResult({ session, candidateId, applicationId, positionId }) {
         ? orchestration.durationSec
         : session.voice?.durationSec ?? null
     },
+    promptVersion: orchestration.promptVersion || process.env.PUBLIC_AI_VOICE_PROMPT_VERSION || 'voice-prompt-v1',
     scoringVersion: orchestration.scoringVersion || SCORING_VERSION,
     rubricVersion: orchestration.rubricVersion || RUBRIC_VERSION,
     rawModelResponse: null,


### PR DESCRIPTION
### Motivation

- Improve security by avoiding exposure of long-lived provider credentials to browsers and minting short-lived, single-session realtime credentials.  
- Prevent abuse and overload by adding rate limits to realtime credential issuance and transcript ingestion.  
- Ensure transcript payloads are bounded and `/complete` is idempotent while preserving traceability via audit metadata.

### Description

- Reworked realtime credential flow in `api/publicAiVoiceInterview.js` to request short TTL provider sessions (`expires_in: 120`), return only an ephemeral `client_secret` shape to the client, persist server-side realtime-session metadata, and refuse issuing a new active realtime session when one is still valid (returns `409`).
- Added endpoint-specific in-memory rate limiting and a small generic limiter helper (`isRateLimited`) with separate state for `/realtime-session` and `/transcript`, controlled by env vars `PUBLIC_AI_REALTIME_RATE_LIMIT_*` and `PUBLIC_AI_TRANSCRIPT_RATE_LIMIT_*`.
- Enforced transcript payload bounds by introducing `TRANSCRIPT_MAX_TURNS_PER_BATCH` and `TRANSCRIPT_MAX_TEXT_LENGTH` (env-overridable) and rejecting batches that are empty, too large, or contain oversized turns before normalization/storage.
- Made `/ai-voice-interview/:token/complete` idempotent by using a conditional update (`{ status: { $ne: 'completed' } }`) and returning a replay-safe response that reports the current completed state/duration when another caller already completed the session.
- Persisted audit fields (`promptVersion`, `rubricVersion`, `scoringVersion`) on session updates and exposed `promptVersion` through orchestration construction and final AI result documents to improve traceability (changes in `services/aiVoiceInterviewOrchestrator.js` and `services/aiVoiceInterviewScoring.js`).

### Testing

- Performed syntax/consistency checks: `node --check api/publicAiVoiceInterview.js` succeeded.  
- Performed syntax/consistency checks: `node --check services/aiVoiceInterviewOrchestrator.js` succeeded.  
- Performed syntax/consistency checks: `node --check services/aiVoiceInterviewScoring.js` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69982bb240848332aab2ec748ff183b1)