### PR TITLE
Add session mode guard to public text interview flow

### DIFF
--- a/api/publicAiInterview.js
+++ b/api/publicAiInterview.js
@@ -125,6 +125,10 @@ router.get('/ai-interview/:token', async (req, res) => {
       return res.status(404).json({ error: 'session_not_found' });
     }
 
+    if (normalizeSessionMode(session.mode) !== 'text') {
+      return res.status(400).json({ error: 'session_mode_mismatch' });
+    }
+
     let candidate = null;
     let position = null;
 
@@ -170,6 +174,10 @@ router.post('/ai-interview/:token/submit', async (req, res) => {
 
     if (!session) {
       return res.status(404).json({ error: 'session_not_found' });
+    }
+
+    if (normalizeSessionMode(session.mode) !== 'text') {
+      return res.status(400).json({ error: 'session_mode_mismatch' });
     }
 
     if (session.status === 'completed') {

--- a/public/ai-interview.js
+++ b/public/ai-interview.js
@@ -82,6 +82,17 @@
         return null;
       }
 
+      if (response.status === 400) {
+        const error = await response.json().catch(() => ({}));
+        if (error.error === 'session_mode_mismatch') {
+          renderMessage(
+            'Incorrect interview link',
+            'This invite is for a voice interview. Please use the correct link.'
+          );
+          return null;
+        }
+      }
+
       if (!response.ok) {
         renderMessage('Unable to load interview', 'Please refresh the page or try again later.');
         return null;
@@ -233,6 +244,8 @@
           const message =
             error.error === 'session_already_completed'
               ? 'This interview has already been submitted.'
+              : error.error === 'session_mode_mismatch'
+                ? 'This invite is for a voice interview. Please use the correct link.'
               : 'Unable to submit your interview. Please try again.';
           messageBox.textContent = message;
           messageBox.classList.remove('hidden');


### PR DESCRIPTION
### Motivation
- Prevent candidates from loading or submitting a voice-mode AI interview through the text-only public endpoints.
- Surface a clear candidate-facing message when the wrong interview mode is accessed so candidates know to use the correct link.

### Description
- Added a mode gate to `GET /ai-interview/:token` that uses `normalizeSessionMode(session.mode)` and returns `400 { error: 'session_mode_mismatch' }` for non-text sessions in `api/publicAiInterview.js`.
- Added the same mode gate to `POST /ai-interview/:token/submit` to block submissions for voice-mode sessions in `api/publicAiInterview.js`.
- Updated `public/ai-interview.js` to handle `session_mode_mismatch` on session fetch and submission and render a candidate-facing message: “This invite is for a voice interview. Please use the correct link.”

### Testing
- Ran syntax checks with `node --check api/publicAiInterview.js && node --check public/ai-interview.js`, which passed.
- Attempted an end-to-end browser check (Playwright) to capture a screenshot of the public page, but navigation failed with `ERR_EMPTY_RESPONSE` because no local web server was available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69982e5d9fa88332a6e2a3643e13ad2a)