### PR TITLE
Expand AI interview result payload for recruiter panel

### DIFF
--- a/api/hrAiInterview.js
+++ b/api/hrAiInterview.js
@@ -107,10 +107,19 @@ router.get('/ai-interview/application/:applicationId', async (req, res) => {
         ? {
             scores: result.scores,
             verdict: result.verdict,
+            mode: result.mode,
             summary: result.summary,
             strengths: result.strengths,
             risks: result.risks,
             recommendedNextSteps: result.recommendedNextSteps,
+            evidence: result.evidence,
+            timeline: result.timeline,
+            rubricVersion: result.rubricVersion,
+            scoringVersion: result.scoringVersion,
+            voiceSummary: result.voiceSummary,
+            transcriptTurns: result.transcriptTurns,
+            highlights: result.highlights,
+            evidenceQuotes: result.evidenceQuotes,
             createdAt: result.createdAt
           }
         : null


### PR DESCRIPTION
### Motivation
- The recruiter panel and UI normalization expect additional top-level result fields (mode, evidence, timeline, rubric/scoring versions and voice-specific summary fields) to render voice and text interview details without breaking existing behavior.

### Description
- Updated the `GET /api/hr/ai-interview/application/:applicationId` response in `api/hrAiInterview.js` to preserve existing `result` keys and add `mode`, `evidence`, `timeline`, `rubricVersion`, `scoringVersion`, and voice-related fields `voiceSummary`, `transcriptTurns`, `highlights`, and `evidenceQuotes` to the returned `result` projection.

### Testing
- Verified syntax by running `node -c api/hrAiInterview.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69982f6ca4c88332a844a55c5911701c)