### PR TITLE
Centralize realtime AI voice interview config and add maxDurationSec + allowInterruptions

### DIFF
--- a/utils/aiVoiceInterviewConfig.js
+++ b/utils/aiVoiceInterviewConfig.js
@@ -18,11 +18,22 @@ function getAiVoiceInterviewConfig() {
   };
 }
 
+function getAiVoiceInterviewRealtimeConfig() {
+  return {
+    model: process.env.OPENAI_REALTIME_MODEL || 'gpt-4o-realtime-preview-2024-12-17',
+    voice: process.env.OPENAI_REALTIME_VOICE || 'alloy',
+    transcriptionModel: process.env.OPENAI_REALTIME_TRANSCRIPTION_MODEL || 'gpt-4o-mini-transcribe',
+    maxDurationSec: Number(process.env.PUBLIC_AI_REALTIME_MAX_DURATION_SEC || 600),
+    allowInterruptions: isTruthy(process.env.PUBLIC_AI_REALTIME_ALLOW_INTERRUPTION ?? 'true')
+  };
+}
+
 function isAiVoiceInterviewEnabled() {
   return getAiVoiceInterviewConfig().enabled;
 }
 
 module.exports = {
   getAiVoiceInterviewConfig,
+  getAiVoiceInterviewRealtimeConfig,
   isAiVoiceInterviewEnabled
 };


### PR DESCRIPTION
### Motivation
- Centralize realtime model/voice/transcription defaults and expose additional realtime controls in one place to avoid scattered env lookups and make the `realtimeConfig` response extensible.
- Surface new runtime controls for session duration and whether interruptions are allowed so clients can adapt UI/behavior consistently.

### Description
- Added `getAiVoiceInterviewRealtimeConfig()` in `utils/aiVoiceInterviewConfig.js` to return `model`, `voice`, `transcriptionModel`, `maxDurationSec`, and `allowInterruptions` with defaults sourced from env vars `OPENAI_REALTIME_MODEL`, `OPENAI_REALTIME_VOICE`, `OPENAI_REALTIME_TRANSCRIPTION_MODEL`, `PUBLIC_AI_REALTIME_MAX_DURATION_SEC` (default `600`), and `PUBLIC_AI_REALTIME_ALLOW_INTERRUPTION` (default `true`).
- Updated `api/publicAiVoiceInterview.js` to require `getAiVoiceInterviewRealtimeConfig()` and use `REALTIME_CONFIG` for realtime session creation payload and for fallback `session` values when issuing realtime credentials.
- Extended the `GET /ai-voice-interview/:token` response `realtimeConfig` to include `maxDurationSec` and `allowInterruptions` while preserving existing `model`, `voice`, and `transcriptionModel` fields for compatibility.

### Testing
- Ran static checks: `node --check api/publicAiVoiceInterview.js` which succeeded. 
- Ran static checks: `node --check utils/aiVoiceInterviewConfig.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69982fe317a8833289ad2465e7961117)