### PR TITLE
Add transport metadata and unsupported transport handling for voice interview realtime sessions

### DIFF
--- a/api/publicAiVoiceInterview.js
+++ b/api/publicAiVoiceInterview.js
@@ -405,6 +405,8 @@ router.post('/ai-voice-interview/:token/realtime-session', async (req, res) => {
     );
 
     return res.status(201).json({
+      transport: 'webrtc',
+      iceServers: [],
       client_secret: {
         value: clientSecret,
         expires_at: realtimeSession?.client_secret?.expires_at || realtimeSession?.expires_at || null


### PR DESCRIPTION
### Motivation
- Expose the realtime session transport and ICE server list so clients can select the correct connection flow and use server-provided STUN/TURN data when available.
- Ensure the existing WebRTC flow continues to work while enabling future transport types and provide a clear error for unsupported transports.
- Preserve backward compatibility by keeping the existing `client_secret` and `session` fields in the realtime response.

### Description
- Add `transport: 'webrtc'` and `iceServers: []` to the `/ai-voice-interview/:token/realtime-session` API response while keeping `client_secret` and `session` unchanged.
- Update the browser client to read `transport` from the realtime response and only continue the WebRTC flow when `transport === 'webrtc'`.
- Pass the server-provided `iceServers` (fallback to `[]`) into `new RTCPeerConnection({ iceServers })` when constructing the peer connection.
- Surface a clear user-facing error via `setStatus('error', ...)` and tear down the connection when an unsupported `transport` value is returned.

### Testing
- Ran `node --check api/publicAiVoiceInterview.js` which succeeded. 
- Ran `node --check public/ai-voice-interview.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699838bc5dd083329682aee40afbb2da)