### PR TITLE
Add realtime transport metadata for AI voice interview sessions

### DIFF
--- a/api/publicAiVoiceInterview.js
+++ b/api/publicAiVoiceInterview.js
@@ -405,6 +405,8 @@ router.post('/ai-voice-interview/:token/realtime-session', async (req, res) => {
     );
 
     return res.status(201).json({
+      transport: 'webrtc',
+      iceServers: Array.isArray(REALTIME_CONFIG.iceServers) ? REALTIME_CONFIG.iceServers : [],
       client_secret: {
         value: clientSecret,
         expires_at: realtimeSession?.client_secret?.expires_at || realtimeSession?.expires_at || null

--- a/utils/aiVoiceInterviewConfig.js
+++ b/utils/aiVoiceInterviewConfig.js
@@ -2,6 +2,17 @@ function isTruthy(value) {
   return String(value || '').trim().toLowerCase() === 'true';
 }
 
+function parseIceServers(rawValue) {
+  if (!rawValue) return [];
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (err) {
+    return [];
+  }
+}
+
 function getAiVoiceInterviewConfig() {
   const featureFlagEnabled =
     isTruthy(process.env.AI_VOICE_INTERVIEW_ENABLED) ||
@@ -19,12 +30,17 @@ function getAiVoiceInterviewConfig() {
 }
 
 function getAiVoiceInterviewRealtimeConfig() {
+  const iceServers = parseIceServers(
+    process.env.PUBLIC_AI_REALTIME_ICE_SERVERS || process.env.OPENAI_REALTIME_ICE_SERVERS || ''
+  );
+
   return {
     model: process.env.OPENAI_REALTIME_MODEL || 'gpt-4o-realtime-preview-2024-12-17',
     voice: process.env.OPENAI_REALTIME_VOICE || 'alloy',
     transcriptionModel: process.env.OPENAI_REALTIME_TRANSCRIPTION_MODEL || 'gpt-4o-mini-transcribe',
     maxDurationSec: Number(process.env.PUBLIC_AI_REALTIME_MAX_DURATION_SEC || 600),
-    allowInterruptions: isTruthy(process.env.PUBLIC_AI_REALTIME_ALLOW_INTERRUPTION ?? 'true')
+    allowInterruptions: isTruthy(process.env.PUBLIC_AI_REALTIME_ALLOW_INTERRUPTION ?? 'true'),
+    iceServers
   };
 }
 


### PR DESCRIPTION
### Motivation
- Make the realtime-session API explicit about the transport so clients can negotiate future transports beyond WebRTC while preserving current behavior.
- Allow clients to receive ICE server configuration from the server so WebRTC negotiation can use STUN/TURN when available.

### Description
- Return `transport: 'webrtc'` and `iceServers` from `POST /api/public/ai-voice-interview/:token/realtime-session` using `REALTIME_CONFIG.iceServers` when present in `api/publicAiVoiceInterview.js`.
- Parse `PUBLIC_AI_REALTIME_ICE_SERVERS` / `OPENAI_REALTIME_ICE_SERVERS` (expected JSON array) in `utils/aiVoiceInterviewConfig.js` via a new `parseIceServers` helper and expose it on the realtime config as `iceServers`.
- Update the browser client in `public/ai-voice-interview.js` to read `transport` and `iceServers` from the realtime-session response, default to `webrtc`, continue the current WebRTC flow for `transport === 'webrtc'`, and throw / show a clear error message for unsupported transport values.
- Wire `iceServers` into `new RTCPeerConnection({ iceServers })` so negotiated ICE servers are used when provided.

### Testing
- Ran syntax checks with `node --check api/publicAiVoiceInterview.js`, `node --check public/ai-voice-interview.js`, and `node --check utils/aiVoiceInterviewConfig.js`, all of which completed successfully.
- Confirmed the changes via a local commit containing the three modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699835da4cac83328994fb81e677f01a)