### PR TITLE
Keep AI interview label and select on one line with inline CSS

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -10436,13 +10436,15 @@ function renderCandidateAiInterviewPanel(candidate, options = {}) {
       : 'Voice mode is currently unavailable.';
     contentEl.innerHTML = '<p class="text-xs text-gray-700">AI Interview not sent yet.</p>';
     actions.push(
-      `<div class="flex flex-wrap items-end gap-2" data-ai-interview-compose>
-        <label class="text-xs text-gray-700" for="candidate-ai-interview-mode-${candidate.id}">Interview mode</label>
-        <select id="candidate-ai-interview-mode-${candidate.id}" class="md-select" data-ai-interview-mode-select>
+      `<div class="flex flex-wrap items-end gap-2" data-ai-interview-compose style="display:flex;flex-wrap:wrap;align-items:flex-end;gap:8px;">
+        <div style="display:flex;align-items:center;gap:8px;white-space:nowrap;">
+          <label class="text-xs text-gray-700" for="candidate-ai-interview-mode-${candidate.id}" style="font-size:12px;color:#374151;">Interview mode</label>
+          <select id="candidate-ai-interview-mode-${candidate.id}" class="md-select" data-ai-interview-mode-select style="min-width:190px;height:36px;padding:6px 10px;border:1px solid #d1d5db;border-radius:8px;background:#fff;color:#111827;">
           <option value="text" selected>Text</option>
           <option value="voice" ${voiceAvailable ? '' : 'disabled'}>${voiceAvailable ? 'Voice' : 'Voice (unavailable)'}</option>
-        </select>
-        <button type="button" class="md-button md-button--filled md-button--small" data-action="ai-send-interview" data-application-id="${
+          </select>
+        </div>
+        <button type="button" class="md-button md-button--filled md-button--small" style="height:36px;padding:0 12px;border-radius:8px;display:inline-flex;align-items:center;gap:6px;" data-action="ai-send-interview" data-application-id="${
           candidate.applicationId
         }" data-candidate-id="${candidate.id}">
           <span class="material-symbols-rounded">smart_toy</span>


### PR DESCRIPTION
### Motivation
- Ensure the Candidate 360 AI Interview controls render correctly even if shared styles are missing by embedding fallback inline CSS directly in the generated HTML. 
- Keep the "Interview mode" label and dropdown on a single line for a compact, usable compose UI.

### Description
- Updated `public/index.js` to wrap the label and select in an inline flex container with `white-space:nowrap` so they stay on one line.
- Added inline styles for the wrapper, `label`, `select`, and the send `button` to provide minimum sizing, spacing, borders, and alignment as a fallback to missing global CSS.
- Kept existing markup and option logic, only enhancing layout and visual defaults.

### Testing
- Ran `npm test` which executed the project test suite and all tests passed (`10` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699841a33d4083328e54885389620b1a)