### PR TITLE
Remove unsupported expires_in from OpenAI realtime session payload

### DIFF
--- a/api/publicAiVoiceInterview.js
+++ b/api/publicAiVoiceInterview.js
@@ -296,7 +296,6 @@ async function createRealtimeSession() {
       body: JSON.stringify({
         model,
         voice: REALTIME_CONFIG.voice,
-        expires_in: 120,
         modalities: ['audio', 'text'],
         input_audio_transcription: {
           model: REALTIME_CONFIG.transcriptionModel


### PR DESCRIPTION
### Motivation
- OpenAI realtime session creation returned `400 Bad Request` due to an unsupported `expires_in` parameter, so the request payload must be aligned with current API expectations.

### Description
- Removed the `expires_in: 120` property from the POST body to `https://api.openai.com/v1/realtime/sessions` in `api/publicAiVoiceInterview.js`, leaving `model`, `voice`, `modalities`, and `input_audio_transcription` unchanged.

### Testing
- Executed `node --check api/publicAiVoiceInterview.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69984725cde883329992c64da0cfcfa1)