### PR TITLE
Improve AI voice interviewer to start and follow JD/CV-based questions

### DIFF
--- a/api/publicAiVoiceInterview.js
+++ b/api/publicAiVoiceInterview.js
@@ -63,7 +63,8 @@ function mapQuestions(questions) {
   if (!Array.isArray(questions)) return [];
   return questions.map((q, index) => ({
     id: deriveQuestionId(q, index),
-    text: q.text || q.question || ''
+    text: q.text || q.question || '',
+    competency: q.competency || q.category || null
   }));
 }
 
@@ -403,6 +404,7 @@ router.get('/ai-voice-interview/:token', async (req, res) => {
       candidateEmail: candidate?.email || null,
       positionTitle: position?.title || session.positionTitle || 'Role',
       templateTitle: session.templateTitle || position?.title || 'AI Voice Interview',
+      interviewQuestions: mapQuestions(session.aiInterviewQuestions),
       realtimeConfig: {
         model: REALTIME_CONFIG.model,
         voice: REALTIME_CONFIG.voice,


### PR DESCRIPTION
### Motivation
- Ensure the AI interviewer initiates questioning immediately and stays focused on recruiter-defined JD/CV-derived questions instead of opening with small talk like "What's new today?".
- Provide the client with normalized question metadata (including competency tags) so the voice flow can follow the configured question set and avoid repeats.

### Description
- Expose `interviewQuestions` in the voice session API (`/api/public/ai-voice-interview/:token`) using `mapQuestions` to return `{id, text, competency}` for each question. 
- Update the voice client (`public/ai-voice-interview.js`) to inject explicit interviewer instructions via `session.update` that prohibit small talk and require asking the provided question list in order. 
- Make the client immediately ask the first configured question on channel open using `response.create` and track asked question IDs in `state.askedQuestionIds` to avoid duplicates. 
- Post each candidate transcript turn to the backend (`/transcript`), consume the backend `nextQuestion` in the response, and automatically send the next question when provided.

### Testing
- Ran syntax checks with `node --check api/publicAiVoiceInterview.js` and `node --check public/ai-voice-interview.js`, both succeeded. 
- Ran the test suite with `npm test`, which completed successfully (all tests passed). 
- Attempted `npm test -- --runInBand` but this failed due to an invalid Node test flag and was not used for validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699849005b888332bf7e6b977dbc809d)