### PR TITLE
Revamp AI interview session styling with inline CSS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,93 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0" />
   <link rel="stylesheet" href="material-theme.css">
   <style>
+    .ai-interview-session-card {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      padding: 16px;
+      border-radius: 14px;
+      border: 1px solid #dbeafe;
+      background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
+      box-shadow: 0 10px 24px rgba(37, 99, 235, 0.08);
+    }
+
+    .ai-interview-session-pills {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .ai-interview-pill {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 5px 10px;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+    }
+
+    .ai-interview-pill--status {
+      color: #1d4ed8;
+      background: #dbeafe;
+    }
+
+    .ai-interview-pill--mode {
+      color: #6d28d9;
+      background: #ede9fe;
+    }
+
+    .ai-interview-pill--verdict {
+      color: #374151;
+      background: #f3f4f6;
+    }
+
+    .ai-interview-session-grid {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .ai-interview-session-meta-item {
+      padding: 12px;
+      border-radius: 10px;
+      border: 1px solid #e5e7eb;
+      background: #ffffff;
+    }
+
+    .ai-interview-session-meta-item--wide {
+      grid-column: 1 / -1;
+    }
+
+    .ai-interview-session-label {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6b7280;
+      margin-bottom: 4px;
+      font-weight: 600;
+    }
+
+    .ai-interview-session-value {
+      font-size: 14px;
+      line-height: 1.45;
+      color: #111827;
+      font-weight: 600;
+      word-break: break-word;
+    }
+
+    .ai-interview-session-note {
+      margin-top: 10px;
+      padding: 10px 12px;
+      border-left: 3px solid #2563eb;
+      border-radius: 8px;
+      background: #eff6ff;
+      color: #1f2937;
+      font-size: 12px;
+      line-height: 1.45;
+    }
+
     /* Employee management layout styles */
     .kpi-grid {
       display: grid;

--- a/public/index.js
+++ b/public/index.js
@@ -10467,28 +10467,28 @@ function renderCandidateAiInterviewPanel(candidate, options = {}) {
   const displayEmail = candidateEmail ? String(candidateEmail) : 'Not provided';
 
   let html = `
-    <div class="space-y-3">
-      <div class="flex flex-wrap items-center gap-2">
-        <span class="px-2 py-1 rounded-full text-[11px] font-semibold bg-blue-50 text-blue-700">${escapeHtml(
+    <div class="ai-interview-session-card">
+      <div class="ai-interview-session-pills">
+        <span class="ai-interview-pill ai-interview-pill--status">${escapeHtml(
           status.label
         )}</span>
-        <span class="px-2 py-1 rounded-full text-[11px] font-semibold bg-purple-50 text-purple-700">Mode: ${escapeHtml(modeLabel)}</span>
+        <span class="ai-interview-pill ai-interview-pill--mode">Mode: ${escapeHtml(modeLabel)}</span>
         ${verdictLabel
-          ? `<span class="px-2 py-1 rounded-full text-[11px] font-semibold bg-gray-100 text-gray-800">${verdictLabel}</span>`
+          ? `<span class="ai-interview-pill ai-interview-pill--verdict">${verdictLabel}</span>`
           : ''}
       </div>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-xs text-gray-700">
-        <div>
-          <div class="text-[11px] uppercase tracking-wide text-gray-500">Candidate Email</div>
-          <div class="text-sm text-gray-900">${escapeHtml(displayEmail)}</div>
+      <div class="ai-interview-session-grid">
+        <div class="ai-interview-session-meta-item">
+          <div class="ai-interview-session-label">Candidate Email</div>
+          <div class="ai-interview-session-value">${escapeHtml(displayEmail)}</div>
         </div>
-        <div>
-          <div class="text-[11px] uppercase tracking-wide text-gray-500">Interview Mode</div>
-          <div class="text-sm text-gray-900">${escapeHtml(modeLabel)}</div>
+        <div class="ai-interview-session-meta-item">
+          <div class="ai-interview-session-label">Interview Mode</div>
+          <div class="ai-interview-session-value">${escapeHtml(modeLabel)}</div>
         </div>
-        <div>
-          <div class="text-[11px] uppercase tracking-wide text-gray-500">Invitation Status</div>
-          <div class="text-sm text-gray-900">${escapeHtml(status.description)}</div>
+        <div class="ai-interview-session-meta-item ai-interview-session-meta-item--wide">
+          <div class="ai-interview-session-label">Invitation Status</div>
+          <div class="ai-interview-session-value">${escapeHtml(status.description)}</div>
         </div>
       </div>
     </div>`;
@@ -10498,7 +10498,7 @@ function renderCandidateAiInterviewPanel(candidate, options = {}) {
       data.session?.status === 'completed'
         ? 'Candidate finished the AI interview. Analysis is being generated and the recruiter will receive an email update.'
         : 'AI interview sent. Waiting for the candidate to complete the interview. The recruiter will be notified automatically.';
-    html += `<p class="text-xs text-gray-700">${escapeHtml(pendingMessage)}</p>`;
+    html += `<p class="ai-interview-session-note">${escapeHtml(pendingMessage)}</p>`;
   } else {
     const { result } = data;
     const scores = result.scores || {};


### PR DESCRIPTION
### Motivation
- Ensure the AI Interview session UI is consistently styled without depending on external utility classes by embedding dedicated CSS into the HTML file.
- Improve the visual hierarchy and readability of the session status, mode, candidate email, and invitation status for recruiters and candidates.

### Description
- Added inline CSS to `public/index.html` that defines `.ai-interview-session-*` classes for the session container, pills, meta tiles, and pending-status note.
- Updated the AI interview markup in `public/index.js` to replace utility-class layout with semantic class names (`ai-interview-pill`, `ai-interview-session-meta-item`, etc.) while preserving existing data rendering logic.
- Kept all existing fields and conditional rendering (scores, summary, transcript handling) intact and only refactored presentation markup.

### Testing
- Ran `node --check public/index.js` which completed successfully.
- Ran `node --check public/ai-interview.js` which completed successfully.
- Attempted `npm start` for visual verification but it failed in this environment due to a missing `OPENAI_API_KEY` environment variable, so the app could not be started for runtime UI capture.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69984ab256708332b077e23e12f9de75)