### PR TITLE
Show immediate completion message on AI voice interview end

### DIFF
--- a/public/ai-voice-interview.js
+++ b/public/ai-voice-interview.js
@@ -20,6 +20,8 @@
     interviewTimer: null
   };
 
+  const interviewCompletedMessage = 'Interview completed. If you need to retake, please contact the company.';
+
   function disableInterviewControls() {
     ['startBtn', 'muteBtn', 'endBtn'].forEach(id => {
       const button = document.getElementById(id);
@@ -98,7 +100,7 @@
       setStatus('completed', 'Interview time limit reached. Submitting your session...');
       await completeInterview('timeout');
       teardownConnection();
-      setStatus('completed', 'Interview ended due to time limit. Thank you.');
+      setStatus('completed', interviewCompletedMessage);
     }, maxDurationSec * 1000);
   }
 
@@ -161,9 +163,10 @@
     document.getElementById('startBtn').addEventListener('click', startVoiceInterview);
     document.getElementById('muteBtn').addEventListener('click', toggleMute);
     document.getElementById('endBtn').addEventListener('click', async () => {
-      await completeInterview('manual_end');
+      setStatus('completed', interviewCompletedMessage);
+      disableInterviewControls();
       teardownConnection();
-      setStatus('completed', 'Interview ended. Thank you.');
+      await completeInterview('manual_end');
     });
     updateMuteButton();
     updateActionButtons();
@@ -256,7 +259,7 @@
       const payload = await response.json().catch(() => ({}));
       if (payload?.status === 'completed_due_to_timeout') {
         disableInterviewControls();
-        setStatus('completed', 'Interview ended due to time limit. Thank you.');
+        setStatus('completed', interviewCompletedMessage);
       }
       return payload;
     } catch (err) {


### PR DESCRIPTION
### Motivation
- Ensure candidates see a clear, consistent completion message immediately after an AI voice interview ends and provide guidance to retake by contacting the company.

### Description
- Added a shared message constant `interviewCompletedMessage` with the text: "Interview completed. If you need to retake, please contact the company." in `public/ai-voice-interview.js`.
- Updated the interview timer timeout flow to display the shared completion message instead of the previous wording when the session ends due to time limit.
- Changed the `End interview` button handler to show the completion message and disable controls immediately, tear down the connection, then call `completeInterview('manual_end')` so feedback is visible right away.
- Reused the same completion message when handling a `completed_due_to_timeout` completion payload for consistent wording across flows.

### Testing
- Ran syntax check with `node --check public/ai-voice-interview.js` which succeeded.
- Ran the repository test suite with `npm test` which completed successfully (`10` tests passed, `0` failed).
- Executed an automated Playwright script against a static server of `public/` to simulate clicking the end button and captured a screenshot showing the completion message, which succeeded and produced an artifact.
- Attempted `npm start` to run the full server which failed due to a missing `OPENAI_API_KEY` environment variable, which is expected in this environment and did not block the UI-focused validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69986a428ac48332ac9c7ae97db7ec9d)