### PR TITLE
Disable Chat Widget by default

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7570,7 +7570,7 @@
           <p class="card-subtitle">Enable or disable the embedded chat widget and update its URL.</p>
           <form id="chatWidgetSettingsForm" class="settings-form">
             <div class="settings-form__toggle">
-              <input type="checkbox" id="chatWidgetEnabled" checked>
+              <input type="checkbox" id="chatWidgetEnabled">
               <label for="chatWidgetEnabled" class="md-label">Enable chat widget</label>
             </div>
             <div class="settings-form__fields settings-form__fields--full">

--- a/public/index.js
+++ b/public/index.js
@@ -527,7 +527,7 @@ function getChatWidgetBaseUrl() {
 }
 
 function isChatWidgetEnabled() {
-  return chatWidgetSettings?.enabled !== false;
+  return chatWidgetSettings?.enabled === true;
 }
 
 function syncChatWidgetVisibility() {

--- a/server.js
+++ b/server.js
@@ -5344,7 +5344,7 @@ init().then(async () => {
       await db.read();
       const stored = db.data.settings?.chatWidget;
       const storedUrl = typeof stored?.url === 'string' ? stored.url.trim() : '';
-      const enabled = typeof stored?.enabled === 'boolean' ? stored.enabled : true;
+      const enabled = typeof stored?.enabled === 'boolean' ? stored.enabled : false;
       res.json({
         url: storedUrl || DEFAULT_CHAT_WIDGET_URL,
         defaultUrl: DEFAULT_CHAT_WIDGET_URL,
@@ -5362,7 +5362,7 @@ init().then(async () => {
       await db.read();
       const stored = db.data.settings?.chatWidget;
       const storedUrl = typeof stored?.url === 'string' ? stored.url.trim() : '';
-      const enabled = typeof stored?.enabled === 'boolean' ? stored.enabled : true;
+      const enabled = typeof stored?.enabled === 'boolean' ? stored.enabled : false;
       res.json({
         url: storedUrl || DEFAULT_CHAT_WIDGET_URL,
         defaultUrl: DEFAULT_CHAT_WIDGET_URL,
@@ -5390,7 +5390,7 @@ init().then(async () => {
       db.data.settings = db.data.settings && typeof db.data.settings === 'object' ? db.data.settings : {};
       const previousEnabled = typeof db.data.settings.chatWidget?.enabled === 'boolean'
         ? db.data.settings.chatWidget.enabled
-        : true;
+        : false;
       const enabled = typeof incomingEnabled === 'boolean' ? incomingEnabled : previousEnabled;
       db.data.settings.chatWidget = { url: incomingUrl || '', enabled };
       await db.write();


### PR DESCRIPTION
### Motivation
- Make the embedded Chat Widget opt-in by default so new installs or unset configurations do not show the widget unless explicitly enabled.

### Description
- Changed public and authenticated settings endpoints to return `enabled: false` when no explicit stored value exists (file: `server.js`).
- Updated the settings save flow so the previous/default `enabled` state is `false` when `enabled` is omitted, preserving a disabled-by-default behavior (file: `server.js`).
- Updated frontend runtime logic so the widget is considered enabled only when `enabled === true` in `chatWidgetSettings` (file: `public/index.js`).
- Removed the default `checked` attribute from the Chat Widget toggle in the Settings UI so the checkbox starts unchecked (file: `public/index.html`).

### Testing
- Ran the unit test suite with `npm test`, and all tests passed (`# pass 10`, `# fail 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699935e07d648332b2193ff945145201)