### PR TITLE
Configure admin and generated-user credential fallbacks via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,11 @@ SESSION_COOKIE_SAMESITE=lax
 CORS_ALLOWED_ORIGINS=https://app.example.com
 
 # Admin bootstrap account
-ADMIN_EMAIL=admin@brillar.io
+ADMIN_EMAIL=admin@b-connect.site
 ADMIN_PASSWORD=admin
+
+# Default password for auto-generated employee login records
+DEFAULT_USER_PASSWORD=bconnet
 
 # Database
 MONGODB_URI=mongodb://localhost:27017

--- a/README.md
+++ b/README.md
@@ -201,8 +201,9 @@ The project ships with a starter `.env.example`. Key groups are summarized below
 
 ### Admin Bootstrap
 
-- `ADMIN_EMAIL`
-- `ADMIN_PASSWORD`
+- `ADMIN_EMAIL` (default `admin@b-connect.site`)
+- `ADMIN_PASSWORD` (default `admin`)
+- `DEFAULT_USER_PASSWORD` (used when creating employee login credentials automatically; default `bconnet`)
 
 ### Database
 

--- a/server.js
+++ b/server.js
@@ -133,8 +133,9 @@ app.options(
 const BODY_LIMIT = process.env.BODY_LIMIT || '3mb';
 
 // Default admin credentials (can be overridden with env vars)
-const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@brillar.io';
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@b-connect.site';
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'admin';
+const DEFAULT_USER_PASSWORD = process.env.DEFAULT_USER_PASSWORD || 'bconnet';
 
 const MANAGER_ROLES = new Set(['manager', 'superadmin']);
 const REQUEST_STATUS_VALUES = ['open', 'in_progress', 'closed'];
@@ -2503,7 +2504,7 @@ function upsertUserForEmployee(emp) {
       changed = true;
     }
     if (!existing.password) {
-      existing.password = 'brillar';
+      existing.password = DEFAULT_USER_PASSWORD;
       changed = true;
     }
     return changed;
@@ -2512,7 +2513,7 @@ function upsertUserForEmployee(emp) {
   db.data.users.push({
     id: emp.id,
     email,
-    password: 'brillar',
+    password: DEFAULT_USER_PASSWORD,
     role,
     employeeId: emp.id
   });


### PR DESCRIPTION
### Motivation
- Replace hardcoded admin and generated-user credentials with environment-configurable values to avoid embedding secrets in source.
- Ensure sane defaults are provided when env vars are not present: admin email `admin@b-connect.site` and password `admin` for the bootstrap account, and `bconnet` as the fallback for auto-created user passwords.

### Description
- Read `ADMIN_EMAIL`, `ADMIN_PASSWORD`, and `DEFAULT_USER_PASSWORD` from the environment in `server.js` and use the specified fallbacks when they are unset by using `process.env` (defaults: `admin@b-connect.site`, `admin`, and `bconnet`).
- Replace hardcoded password literals used when creating or updating autogenerated user records with `DEFAULT_USER_PASSWORD` in `upsertUserForEmployee`.
- Update `.env.example` to include `ADMIN_EMAIL=admin@b-connect.site`, `ADMIN_PASSWORD=admin`, and `DEFAULT_USER_PASSWORD=bconnet`.
- Update the README `Environment Variables` section to document the new defaults for `ADMIN_EMAIL`, `ADMIN_PASSWORD`, and `DEFAULT_USER_PASSWORD`.

### Testing
- Ran `node --check server.js` to validate JavaScript syntax and the updated `server.js` parsed without errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999382b16348332ac909ab26798ab3e)