### PR TITLE
Hide brand logos until branding settings load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5017,7 +5017,7 @@
     <div class="landing-shell">
       <div class="login-card">
         <div class="login-card-header">
-          <img id="loginBrandLogo" src="logo.png" alt="Organization logo" class="brand-logo">
+          <img id="loginBrandLogo" src="logo.png" alt="Organization logo" class="brand-logo" style="visibility: hidden;">
           <p class="login-kicker">Secure workforce access</p>
           <div>
             <h1 id="loginPortalName" class="login-title">Brillar HR Portal</h1>
@@ -5069,7 +5069,7 @@
     <header class="top-app-bar">
       <div class="top-bar-shell">
         <div class="brand-cluster">
-          <img id="appBrandLogo" src="https://static.wixstatic.com/media/34647d_4924e46631c3463abed06f9e3147eba3~mv2.png" alt="Organization logo">
+          <img id="appBrandLogo" src="https://static.wixstatic.com/media/34647d_4924e46631c3463abed06f9e3147eba3~mv2.png" alt="Organization logo" style="visibility: hidden;">
           <div class="brand-text">
             <span id="appPortalName" class="brand-title">Brillar HR Portal</span>
             <span class="brand-tagline">Modern, people-first HR experiences</span>
@@ -7466,7 +7466,7 @@
             </div>
 
             <div class="settings-form__fields settings-form__fields--full">
-              <img id="organizationLogoPreview" src="logo.png" alt="Organization logo preview" class="brand-logo" style="max-width: 180px; height: auto;">
+              <img id="organizationLogoPreview" src="logo.png" alt="Organization logo preview" class="brand-logo" style="max-width: 180px; height: auto; visibility: hidden;">
             </div>
 
             <button type="submit" class="md-button md-button--filled md-button--small settings-form__submit">

--- a/public/index.js
+++ b/public/index.js
@@ -1060,6 +1060,7 @@ function adaptSearchResultToCandidate(result) {
 
 document.addEventListener('DOMContentLoaded', () => {
   setupTabGroupMenus();
+  setBrandingImagesLoadingState(true);
   applyOrganizationBranding();
   loadPublicOrganizationBranding();
   loadPublicChatWidgetSettings();
@@ -8307,6 +8308,15 @@ function applyOrganizationBranding() {
   });
 }
 
+function setBrandingImagesLoadingState(isLoading) {
+  const logoIds = ['loginBrandLogo', 'appBrandLogo', 'organizationLogoPreview'];
+  logoIds.forEach(id => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.style.visibility = isLoading ? 'hidden' : 'visible';
+  });
+}
+
 
 async function loadPublicOrganizationBranding() {
   try {
@@ -8325,6 +8335,8 @@ async function loadPublicOrganizationBranding() {
   } catch (err) {
     console.error('Unable to load public organization branding', err);
     return organizationSettings;
+  } finally {
+    setBrandingImagesLoadingState(false);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the app from briefly showing stale or default branding images while organization branding is being fetched so users don't see incorrect logos during startup. 

### Description
- Set inline `visibility: hidden` on the login, header, and organization-preview image elements (`loginBrandLogo`, `appBrandLogo`, `organizationLogoPreview`) in `public/index.html` so they are hidden on initial render.  
- Add `setBrandingImagesLoadingState(isLoading)` to `public/index.js` and call it at startup to keep images hidden while branding loads.  
- Reveal the images after the branding fetch completes by invoking `setBrandingImagesLoadingState(false)` in the `finally` block of `loadPublicOrganizationBranding()`, and continue to apply branding via `applyOrganizationBranding()` which updates `src` and document title. 

### Testing
- Ran `node --check public/index.js` and it passed.  
- Ran `node --check server.js` and it passed.  
- Ran `npm test --silent` and the test suite passed (`# pass 10`, `# fail 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699bd85309248332bbc6215e2100c594)