### PR TITLE
Use finance salary for intern payroll

### DIFF
--- a/server.js
+++ b/server.js
@@ -6156,11 +6156,9 @@ init().then(async () => {
 
       if (internSegmentStart <= internSegmentEnd) {
         const internWorkingDays = countWorkingDaysInRange(internSegmentStart, internSegmentEnd);
-        const internMonthlySalary =
-          typeof employee.internshipMonthlySalary === 'number'
-          && Number.isFinite(employee.internshipMonthlySalary)
-            ? employee.internshipMonthlySalary
-            : 300000;
+        const internMonthlySalary = Number.isFinite(employee.internshipMonthlySalary)
+          ? employee.internshipMonthlySalary
+          : 0;
         const internDailyRate = internMonthlySalary / workingDaysInMonth;
         totalPay += internDailyRate * internWorkingDays;
       }
@@ -6178,7 +6176,7 @@ init().then(async () => {
     const isFullTimeThisMonth = fullTimeStartDate && fullTimeStartDate <= activeEnd;
     const monthlySalaryToUse = isFullTimeThisMonth
       ? Number.isFinite(employee.monthlySalary) ? employee.monthlySalary : 0
-      : (Number.isFinite(employee.internshipMonthlySalary) ? employee.internshipMonthlySalary : 300000);
+      : Number.isFinite(employee.internshipMonthlySalary) ? employee.internshipMonthlySalary : 0;
 
     const segmentWorkingDays = countWorkingDaysInRange(activeStart, activeEnd);
     const dailyRate = monthlySalaryToUse / workingDaysInMonth;
@@ -6255,7 +6253,9 @@ init().then(async () => {
           {
             ...dateContext,
             monthlySalary: Number.isFinite(salaryRecord?.amount) ? salaryRecord.amount : 0,
-            internshipMonthlySalary: rawEmployee?.internshipMonthlySalary
+            internshipMonthlySalary: Number.isFinite(salaryRecord?.amount)
+              ? salaryRecord.amount
+              : Number.isFinite(rawEmployee?.internshipMonthlySalary) ? rawEmployee.internshipMonthlySalary : 0
           },
           payrollYear,
           payrollMonthNumber


### PR DESCRIPTION
### Motivation
- Remove the hardcoded 300,000 MMK intern salary fallback that caused interns to always be paid a fixed amount.
- Make intern gross-pay calculations use the salary configured in Finance → Active Employees when available.
- Ensure payroll is correct for split-month internship→full-time transitions and when finance salary records exist.

### Description
- Replaced the hardcoded `300000` fallback with a zero default in `calculateMonthlyPayForEmployee` so missing intern salary no longer implies a fixed amount. 
- Use the finance salary record amount as the `internshipMonthlySalary` when building payroll summaries in `buildPayrollSummaryEntry`, falling back to an employee `internshipMonthlySalary` value only when no finance record exists, otherwise defaulting to `0`.
- Adjusted the logic for `monthlySalaryToUse` to default to `0` when no internship salary is provided.
- Modified file: `server.js` (payroll calculation and payroll-summary construction changes).

### Testing
- Ran `node --check server.js` with no syntax errors (success).
- Ran `npm test` and all tests passed (`12` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29190a26588331ab86ab70baa23f03)