### PR TITLE
Allow past leave cancellation and add manual leave adjustments (Adjust Leave)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6697,7 +6697,7 @@
             </button>
             <button id="leaveUpdateBtn" class="md-button md-button--outlined" type="button">
               <span class="material-symbols-rounded">edit_calendar</span>
-              Update Leave
+              Adjust Leave
             </button>
             <button id="addEmployeeBtn" class="md-button md-button--filled">
               <span class="material-symbols-rounded">person_add</span>
@@ -6821,7 +6821,7 @@
         >
           <div class="modal-card modal-card--wide leave-update-modal">
             <button type="button" id="leaveUpdateCloseBtn" class="modal-close material-symbols-rounded">close</button>
-            <h3 id="leaveUpdateTitle" class="modal-title">Update Leave Entitlements</h3>
+            <h3 id="leaveUpdateTitle" class="modal-title">Adjust Leave</h3>
             <div class="modal-body-scroll">
               <div class="leave-update-search">
                 <label class="md-label" for="leaveUpdateSearch">Search employees</label>

--- a/public/index.js
+++ b/public/index.js
@@ -169,10 +169,15 @@ function normalizeLeaveEntry(entry, type) {
   if (entry && typeof entry === 'object') {
     return {
       balance: Number.isFinite(entry.balance) ? entry.balance : 0,
-      yearlyAllocation: Number.isFinite(entry.yearlyAllocation) ? entry.yearlyAllocation : defaults.yearlyAllocation,
+      yearlyAllocation: Number.isFinite(entry.yearlyAllocation)
+        ? entry.yearlyAllocation
+        : Number.isFinite(entry.entitlement) ? entry.entitlement : defaults.yearlyAllocation,
       monthlyAccrual: Number.isFinite(entry.monthlyAccrual) ? entry.monthlyAccrual : defaults.monthlyAccrual,
       taken: Number.isFinite(entry.taken) ? entry.taken : 0,
-      accrued: Number.isFinite(entry.accrued) ? entry.accrued : null
+      accrued: Number.isFinite(entry.accrued) ? entry.accrued : Number.isFinite(entry.earned) ? entry.earned : null,
+      manualAdjustment: Number.isFinite(entry.manualAdjustment)
+        ? entry.manualAdjustment
+        : Number.isFinite(entry.adjustment) ? entry.adjustment : 0
     };
   }
   const numericBalance = Number(entry);
@@ -181,7 +186,8 @@ function normalizeLeaveEntry(entry, type) {
     yearlyAllocation: defaults.yearlyAllocation,
     monthlyAccrual: defaults.monthlyAccrual,
     taken: 0,
-    accrued: null
+    accrued: null,
+    manualAdjustment: 0
   };
 }
 
@@ -241,49 +247,49 @@ function renderLeaveUpdateList() {
       const typeLabel = `${capitalize(type)} Leave`;
       const takenValue = roundToOneDecimal(entry.taken);
       const balanceValue = roundToOneDecimal(entry.balance);
-      const takenLabel = `${takenValue.toFixed(1)} days taken`;
-      const balanceOverrideId = `leave-balance-override-${empId}-${type}`;
-      const takenId = `leave-taken-${empId}-${type}`;
-      const projectedEntitlementId = `leave-projected-entitlement-${empId}-${type}`;
-      const projectedEntitlementValue = roundToOneDecimal(balanceValue + takenValue);
+      const adjustmentValue = roundToOneDecimal(entry.manualAdjustment);
+      const takenLabel = `${takenValue.toFixed(1)} days taken • ${adjustmentValue.toFixed(1)} adjusted`;
+      const currentBalanceId = `leave-current-balance-${empId}-${type}`;
+      const adjustmentId = `leave-adjustment-${empId}-${type}`;
+      const projectedBalanceId = `leave-projected-balance-${empId}-${type}`;
       return `
-        <div class="leave-update-row" data-leave-type="${escapeHtml(type)}" data-leave-taken="${escapeHtml(takenValue.toString())}">
+        <div class="leave-update-row" data-leave-type="${escapeHtml(type)}" data-current-balance="${escapeHtml(balanceValue.toString())}">
           <div class="leave-update-row__label">
             <span>${escapeHtml(typeLabel)}</span>
             <small>${escapeHtml(takenLabel)}</small>
           </div>
           <div class="leave-update-row__field">
-            <label for="${escapeHtml(balanceOverrideId)}">Current balance (override)</label>
+            <label for="${escapeHtml(currentBalanceId)}">Current balance</label>
             <input
-              id="${escapeHtml(balanceOverrideId)}"
+              id="${escapeHtml(currentBalanceId)}"
               class="md-input"
               type="number"
               step="0.5"
               value="${escapeHtml(balanceValue.toFixed(1))}"
-              data-leave-field="balance-override"
-            >
-          </div>
-          <div class="leave-update-row__field">
-            <label for="${escapeHtml(takenId)}">Leave taken</label>
-            <input
-              id="${escapeHtml(takenId)}"
-              class="md-input"
-              type="number"
-              step="0.5"
-              value="${escapeHtml(takenValue.toFixed(1))}"
-              data-leave-field="taken"
+              data-leave-field="current-balance"
               readonly
             >
           </div>
           <div class="leave-update-row__field">
-            <label for="${escapeHtml(projectedEntitlementId)}">Entitlement (auto-adjusted)</label>
+            <label for="${escapeHtml(adjustmentId)}">Add / remove days</label>
             <input
-              id="${escapeHtml(projectedEntitlementId)}"
+              id="${escapeHtml(adjustmentId)}"
               class="md-input"
               type="number"
               step="0.5"
-              value="${escapeHtml(projectedEntitlementValue.toFixed(1))}"
-              data-leave-field="entitlement"
+              value="0.0"
+              data-leave-field="adjustment"
+            >
+          </div>
+          <div class="leave-update-row__field">
+            <label for="${escapeHtml(projectedBalanceId)}">Projected balance</label>
+            <input
+              id="${escapeHtml(projectedBalanceId)}"
+              class="md-input"
+              type="number"
+              step="0.5"
+              value="${escapeHtml(balanceValue.toFixed(1))}"
+              data-leave-field="projected-balance"
               readonly
             >
           </div>
@@ -303,7 +309,7 @@ function renderLeaveUpdateList() {
         <div class="leave-update-card__actions">
           <button class="md-button md-button--filled md-button--small" data-leave-save="${escapeHtml(String(empId))}">
             <span class="material-symbols-rounded">save</span>
-            Update Leave
+            Adjust Leave
           </button>
         </div>
       </article>
@@ -361,16 +367,16 @@ function closeLeaveUpdateModal() {
 
 function updateLeaveUpdateRowBalance(row) {
   if (!row) return;
-  const balanceOverrideInput = row.querySelector('[data-leave-field="balance-override"]');
-  const entitlementInput = row.querySelector('[data-leave-field="entitlement"]');
-  if (!balanceOverrideInput || !entitlementInput) return;
-  const balanceOverrideValue = Number(balanceOverrideInput.value);
-  const takenValue = Number(row.dataset.leaveTaken);
-  if (!Number.isFinite(balanceOverrideValue)) return;
-  const projectedEntitlement = roundToOneDecimal(
-    balanceOverrideValue + (Number.isFinite(takenValue) ? takenValue : 0)
+  const adjustmentInput = row.querySelector('[data-leave-field="adjustment"]');
+  const projectedInput = row.querySelector('[data-leave-field="projected-balance"]');
+  if (!adjustmentInput || !projectedInput) return;
+  const adjustmentValue = Number(adjustmentInput.value);
+  const currentBalance = Number(row.dataset.currentBalance);
+  const projectedBalance = roundToOneDecimal(
+    (Number.isFinite(currentBalance) ? currentBalance : 0) +
+    (Number.isFinite(adjustmentValue) ? adjustmentValue : 0)
   );
-  entitlementInput.value = projectedEntitlement.toFixed(1);
+  projectedInput.value = projectedBalance.toFixed(1);
 }
 
 async function saveLeaveUpdatesForEmployee(employeeId, buttonEl) {
@@ -379,32 +385,28 @@ async function saveLeaveUpdatesForEmployee(employeeId, buttonEl) {
   if (!employee) return;
   const card = buttonEl instanceof HTMLElement ? buttonEl.closest('.leave-update-card') : null;
   if (!card) return;
-  const updatedBalances = { ...(employee.leaveBalances || {}) };
+  const adjustments = {};
 
   SUPPORTED_LEAVE_TYPES.forEach(type => {
     const row = card.querySelector(`[data-leave-type="${type}"]`);
-    const balanceOverrideInput = row?.querySelector('[data-leave-field="balance-override"]');
-    const balanceOverrideValue = balanceOverrideInput ? Number(balanceOverrideInput.value) : NaN;
-    const currentEntry = normalizeLeaveEntry(updatedBalances[type], type);
-    const updatedBalance = Number.isFinite(balanceOverrideValue)
-      ? roundToOneDecimal(balanceOverrideValue)
-      : currentEntry.balance;
-    const updatedEntitlement = roundToOneDecimal(updatedBalance + currentEntry.taken);
-    updatedBalances[type] = {
-      ...currentEntry,
-      yearlyAllocation: updatedEntitlement,
-      monthlyAccrual: currentEntry.monthlyAccrual,
-      balance: updatedBalance,
-      accrued: updatedEntitlement
-    };
+    const adjustmentInput = row?.querySelector('[data-leave-field="adjustment"]');
+    const adjustmentValue = adjustmentInput ? Number(adjustmentInput.value) : NaN;
+    if (Number.isFinite(adjustmentValue) && adjustmentValue !== 0) {
+      adjustments[type] = roundToOneDecimal(adjustmentValue);
+    }
   });
+
+  if (!Object.keys(adjustments).length) {
+    showToast('Enter at least one positive or negative adjustment.', 'warning');
+    return;
+  }
 
   setButtonLoading(buttonEl, true);
   try {
-    const res = await apiFetch(`/employees/${employeeId}`, {
-      method: 'PUT',
+    const res = await apiFetch(`/employees/${employeeId}/leave-adjustments`, {
+      method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ leaveBalances: updatedBalances })
+      body: JSON.stringify({ adjustments })
     });
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
@@ -416,7 +418,7 @@ async function saveLeaveUpdatesForEmployee(employeeId, buttonEl) {
         String(emp.id) === String(employeeId) ? updatedEmployee : emp
       );
     }
-    showToast('Leave balances updated.', 'success');
+    showToast('Leave adjustments applied.', 'success');
     renderLeaveUpdateList();
     await loadEmployeesManage();
     await loadEmployeesPortal();
@@ -425,7 +427,7 @@ async function saveLeaveUpdatesForEmployee(employeeId, buttonEl) {
     }
   } catch (err) {
     console.error('Failed to update leave balances', err);
-    showToast(err.message || 'Unable to update leave balances.', 'error');
+    showToast(err.message || 'Unable to adjust leave balances.', 'error');
   } finally {
     setButtonLoading(buttonEl, false);
   }
@@ -11493,7 +11495,7 @@ async function init() {
       saveLeaveUpdatesForEmployee(employeeId, button);
     });
     leaveUpdateList.addEventListener('input', event => {
-      const input = event.target.closest('[data-leave-field="balance-override"]');
+      const input = event.target.closest('[data-leave-field="adjustment"]');
       if (!input) return;
       const row = input.closest('.leave-update-row');
       updateLeaveUpdateRowBalance(row);
@@ -11920,9 +11922,7 @@ async function loadManagerApplications() {
       if (app.halfDay) {
         typeLabel += ` (Half Day${app.halfDayPeriod ? ' ' + app.halfDayPeriod : ''})`;
       }
-      // Calculate cancel eligibility: current date before "from" date
-      const now = new Date();
-      const canCancel = new Date(app.from) > now;
+      const canCancel = isManagerRole(currentUser) || new Date(app.from) > new Date();
       return `
         <article class="list-card">
           <div class="list-card__main">
@@ -12018,18 +12018,20 @@ async function loadManagerUpcomingLeaves(showCancel = false) {
   const oneMonthLater = new Date();
   oneMonthLater.setMonth(now.getMonth() + 1);
 
-  const filtered = allApproved.filter(app => {
-    const from = new Date(app.from);
-    const to = new Date(app.to);
-    return (
-      (from >= now && from <= oneMonthLater) ||
-      (to >= now && to <= oneMonthLater) ||
-      (from <= now && to >= now)
-    );
-  });
+  const filtered = showCancel
+    ? allApproved
+    : allApproved.filter(app => {
+      const from = new Date(app.from);
+      const to = new Date(app.to);
+      return (
+        (from >= now && from <= oneMonthLater) ||
+        (to >= now && to <= oneMonthLater) ||
+        (from <= now && to >= now)
+      );
+    });
 
   if (!filtered.length) {
-    list.innerHTML = `<div class="text-muted" style="font-style:italic;">No upcoming approved leaves in the next 1 month.</div>`;
+    list.innerHTML = `<div class="text-muted" style="font-style:italic;">${showCancel ? 'No approved leaves available to cancel.' : 'No upcoming approved leaves in the next 1 month.'}</div>`;
     return;
   }
 
@@ -12043,8 +12045,7 @@ async function loadManagerUpcomingLeaves(showCancel = false) {
     if (app.halfDay) {
       typeLabel += ` (Half Day${app.halfDayPeriod ? ' ' + app.halfDayPeriod : ''})`;
     }
-    // Show cancel if approved leave in future
-    const canCancel = new Date(app.from) > now;
+    const canCancel = showCancel ? isManagerRole(currentUser) : new Date(app.from) > now;
     const icon = typeIcon[app.type] || 'event_available';
     return `
       <article class="list-card">

--- a/server.js
+++ b/server.js
@@ -1622,7 +1622,7 @@ function canViewRequest(requestRecord, currentUser, employees = [], users = []) 
 
 function normalizeLeaveBalanceEntry(entry, defaults) {
   const baseDefaults =
-    defaults || { balance: 0, yearlyAllocation: 0, monthlyAccrual: 0, accrued: 0, taken: 0 };
+    defaults || { balance: 0, yearlyAllocation: 0, monthlyAccrual: 0, accrued: 0, taken: 0, manualAdjustment: 0 };
   const balanceValue = Number(
     typeof entry === 'object' && entry !== null && 'balance' in entry
       ? entry.balance
@@ -1651,6 +1651,12 @@ function normalizeLeaveBalanceEntry(entry, defaults) {
     typeof entry === 'object' && entry !== null && 'taken' in entry ? entry.taken : baseDefaults.taken
   );
 
+  const manualAdjustment = Number(
+    typeof entry === 'object' && entry !== null && 'manualAdjustment' in entry
+      ? entry.manualAdjustment
+      : baseDefaults.manualAdjustment || 0
+  );
+
   const clampToAllocation = value => {
     if (!Number.isFinite(value)) return value;
     return Number.isFinite(yearlyAllocation) ? Math.min(value, yearlyAllocation) : value;
@@ -1669,7 +1675,8 @@ function normalizeLeaveBalanceEntry(entry, defaults) {
     accrued: roundToOneDecimal(
       clampToAllocation(Number.isFinite(accrued) ? accrued : baseDefaults.accrued)
     ),
-    taken: roundToOneDecimal(Number.isFinite(taken) ? taken : baseDefaults.taken)
+    taken: roundToOneDecimal(Number.isFinite(taken) ? taken : baseDefaults.taken),
+    manualAdjustment: roundToOneDecimal(Number.isFinite(manualAdjustment) ? manualAdjustment : 0)
   };
 }
 
@@ -1766,12 +1773,21 @@ function refreshEmployeeLeaveBalances(employee, data, options = {}) {
 
 function formatLeaveBalancesForResponse(balances, { dateNow = new Date(), settings } = {}) {
   const cycle = getCurrentLeaveCycleInfo(dateNow, settings);
-  const toEntry = (entry = {}, defaultEntitlement = 0) => ({
-    entitlement: Number.isFinite(entry?.entitlement) ? entry.entitlement : defaultEntitlement,
-    earned: roundToOneDecimal(entry?.earned || 0),
-    taken: roundToOneDecimal(entry?.taken || 0),
-    balance: roundToOneDecimal(entry?.balance || 0)
-  });
+  const toEntry = (entry = {}, defaultEntitlement = 0) => {
+    const entitlement = Number.isFinite(entry?.entitlement) ? entry.entitlement : defaultEntitlement;
+    const earned = roundToOneDecimal(entry?.earned || entry?.accrued || 0);
+    const adjustment = roundToOneDecimal(entry?.manualAdjustment ?? entry?.adjustment ?? 0);
+    return {
+      entitlement,
+      yearlyAllocation: entitlement,
+      earned,
+      accrued: earned,
+      taken: roundToOneDecimal(entry?.taken || 0),
+      adjustment,
+      manualAdjustment: adjustment,
+      balance: roundToOneDecimal(entry?.balance || 0)
+    };
+  };
 
   return {
     annual: toEntry(balances?.annual, DEFAULT_ENTITLEMENTS.annual),
@@ -4047,6 +4063,55 @@ init().then(async () => {
       await reconcileLearningAssignmentsForEmployees([emp.id]);
     }
     res.json(emp);
+  });
+
+  app.post('/employees/:id/leave-adjustments', authRequired, managerOnly, async (req, res) => {
+    await db.read();
+    const emp = db.data.employees.find(e => e.id == req.params.id);
+    if (!emp) return res.status(404).json({ error: 'Not found' });
+
+    ensureLeaveBalances(emp);
+    const adjustments = req.body && typeof req.body.adjustments === 'object' ? req.body.adjustments : {};
+    const note = typeof req.body?.note === 'string' ? req.body.note.trim() : '';
+    const applied = {};
+
+    SUPPORTED_LEAVE_TYPES.forEach(type => {
+      const delta = Number(adjustments[type]);
+      if (!Number.isFinite(delta) || delta === 0) return;
+      const currentEntry = normalizeLeaveBalanceEntry(emp.leaveBalances[type], DEFAULT_LEAVE_BALANCES[type]);
+      const currentAdjustment = Number(currentEntry.manualAdjustment);
+      const nextAdjustment = roundToOneDecimal((Number.isFinite(currentAdjustment) ? currentAdjustment : 0) + delta);
+      emp.leaveBalances[type] = {
+        ...currentEntry,
+        manualAdjustment: nextAdjustment
+      };
+      applied[type] = roundToOneDecimal(delta);
+    });
+
+    if (!Object.keys(applied).length) {
+      return res.status(400).json({ error: 'Enter at least one leave adjustment.' });
+    }
+
+    emp.leaveAdjustmentHistory = Array.isArray(emp.leaveAdjustmentHistory) ? emp.leaveAdjustmentHistory : [];
+    emp.leaveAdjustmentHistory.push({
+      id: Date.now(),
+      adjustments: applied,
+      note,
+      adjustedBy: req.user?.email || req.user?.username || '',
+      adjustedAt: new Date().toISOString()
+    });
+
+    refreshEmployeeLeaveBalances(emp, db.data);
+    await db.write();
+
+    const { formatted } = await getComputedLeaveBalances(emp, {
+      dateNow: new Date(),
+      applications: db.data.applications,
+      holidays: db.data.holidays,
+      settings: db.data.settings
+    });
+
+    res.json({ ...emp, leaveBalances: formatted });
   });
 
   app.patch('/employees/:id/status', authRequired, managerOnly, async (req, res) => {
@@ -8135,9 +8200,10 @@ init().then(async () => {
       return res.status(400).json({ error: 'Already cancelled/rejected' });
     }
 
-    // Only allow cancel if today is before leave "from" date
+    // Employees may only cancel future leave; managers/admins may also cancel past leave
+    // so incorrectly recorded approved days are credited back during balance refresh.
     const now = new Date();
-    if (new Date(appObjApp.from) <= now) {
+    if (!isManagerRole(req.user.role) && new Date(appObjApp.from) <= now) {
       return res.status(400).json({ error: 'Cannot cancel after leave started' });
     }
 

--- a/services/leaveAccrualService.js
+++ b/services/leaveAccrualService.js
@@ -10,9 +10,9 @@ const NEGATIVE_BALANCE_LIMITS = {
 };
 
 const DEFAULT_LEAVE_BALANCES = {
-  annual: { balance: 0, yearlyAllocation: 10, monthlyAccrual: 10 / 12, accrued: 0, taken: 0 },
-  casual: { balance: 0, yearlyAllocation: 5, monthlyAccrual: 5 / 12, accrued: 0, taken: 0 },
-  medical: { balance: 0, yearlyAllocation: 14, monthlyAccrual: 14 / 12, accrued: 0, taken: 0 },
+  annual: { balance: 0, yearlyAllocation: 10, monthlyAccrual: 10 / 12, accrued: 0, taken: 0, manualAdjustment: 0 },
+  casual: { balance: 0, yearlyAllocation: 5, monthlyAccrual: 5 / 12, accrued: 0, taken: 0, manualAdjustment: 0 },
+  medical: { balance: 0, yearlyAllocation: 14, monthlyAccrual: 14 / 12, accrued: 0, taken: 0, manualAdjustment: 0 },
   cycleStart: null,
   cycleEnd: null,
   lastAccrualRun: null,
@@ -152,7 +152,8 @@ function normalizeLeaveBalanceEntry(entry, defaults) {
     yearlyAllocation: 0,
     monthlyAccrual: 0,
     accrued: 0,
-    taken: 0
+    taken: 0,
+    manualAdjustment: 0
   };
 
   const balance = Number(
@@ -178,6 +179,11 @@ function normalizeLeaveBalanceEntry(entry, defaults) {
       ? entry.taken
       : baseDefaults.taken
   );
+  const manualAdjustment = Number(
+    typeof entry === 'object' && entry !== null && 'manualAdjustment' in entry
+      ? entry.manualAdjustment
+      : baseDefaults.manualAdjustment || 0
+  );
 
   const clampToAllocation = value => {
     if (!Number.isFinite(value)) return value;
@@ -197,7 +203,8 @@ function normalizeLeaveBalanceEntry(entry, defaults) {
     accrued: roundToOneDecimal(
       clampToAllocation(Number.isFinite(accrued) ? accrued : baseDefaults.accrued)
     ),
-    taken: roundToOneDecimal(Number.isFinite(taken) ? taken : baseDefaults.taken)
+    taken: roundToOneDecimal(Number.isFinite(taken) ? taken : baseDefaults.taken),
+    manualAdjustment: roundToOneDecimal(Number.isFinite(manualAdjustment) ? manualAdjustment : 0)
   };
 }
 
@@ -420,14 +427,17 @@ function buildEmployeeLeaveState(employee, applications, options = {}) {
     const accruedValue = accrued[type] || 0;
     const takenValue = taken[type] || 0;
     const cappedAccrued = Math.min(accruedValue, entitlement);
-    const balance = roundToOneDecimal(cappedAccrued - takenValue);
+    const adjustment = Number(employee?.leaveBalances?.[type]?.manualAdjustment);
+    const manualAdjustment = Number.isFinite(adjustment) ? adjustment : 0;
+    const balance = roundToOneDecimal(cappedAccrued - takenValue + manualAdjustment);
     balances[type] = {
       ...normalizeLeaveBalanceEntry(employee?.leaveBalances?.[type], overriddenDefaults),
       monthlyAccrual,
       yearlyAllocation: entitlement,
       accrued: roundToOneDecimal(cappedAccrued),
       taken: roundToOneDecimal(takenValue),
-      balance
+      balance,
+      manualAdjustment: roundToOneDecimal(manualAdjustment)
     };
   });
 

--- a/services/leaveAccrualService.test.js
+++ b/services/leaveAccrualService.test.js
@@ -154,6 +154,25 @@ test('Accrued balances are capped at the yearly allocation', () => {
   assert.equal(balances.medical.balance, 14);
 });
 
+
+test('Manual leave adjustments increase or decrease computed balances', () => {
+  const asOfDate = new Date('2025-06-30');
+  const employee = {
+    ...createEmployee(new Date('2020-01-01')),
+    leaveBalances: {
+      annual: { manualAdjustment: 1.5 },
+      casual: { manualAdjustment: -1 },
+      medical: { manualAdjustment: 0 }
+    }
+  };
+  const balances = runState(employee, [], asOfDate);
+
+  assert.equal(balances.annual.balance, 11.5);
+  assert.equal(balances.annual.manualAdjustment, 1.5);
+  assert.equal(balances.casual.balance, 4);
+  assert.equal(balances.casual.manualAdjustment, -1);
+});
+
 test('Normalization caps stored balances and accrued values at allocations', () => {
   const defaults = DEFAULT_LEAVE_BALANCES.annual;
   const normalized = normalizeLeaveBalanceEntry({ balance: 10.8, accrued: 10.8 }, defaults);

--- a/utils/leaveAccrual.js
+++ b/utils/leaveAccrual.js
@@ -158,12 +158,16 @@ async function computeAllLeaveBalances(employee, { dateNow = new Date(), applica
       monthsServedInCycle,
       totalLeaveTaken: totals[type]
     });
+    const manualAdjustment = Number(employee?.leaveBalances?.[type]?.manualAdjustment);
+    const adjustment = Number.isFinite(manualAdjustment) ? manualAdjustment : 0;
 
     balances[type] = {
       entitlement: yearEntitlement,
       earned: accruedEarned,
       taken: roundToOneDecimal(totals[type] || 0),
-      balance: accruedBalance
+      adjustment: roundToOneDecimal(adjustment),
+      manualAdjustment: roundToOneDecimal(adjustment),
+      balance: roundToOneDecimal(accruedBalance + adjustment)
     };
   });
 


### PR DESCRIPTION
### Motivation

- Provide admins/managers a way to cancel approved leaves from the past so incorrectly recorded taken days can be removed and balances reconciled. 
- Give HR a simple per-employee tool to add or remove leave days across leave categories (annual, casual, medical) without editing raw stored balances manually. 

### Description

- Allow managers/admins to cancel leave after the `from` date while keeping self-cancellation restricted to future leave by updating the `/applications/:id/cancel` handler and calling `refreshEmployeeLeaveBalances` after cancellation. 
- Add a manager-only API endpoint `POST /employees/:id/leave-adjustments` to persist per-type `manualAdjustment`, record an audit entry in `leaveAdjustmentHistory`, and refresh computed balances after applying deltas. 
- Incorporate `manualAdjustment` into balance computations and response formatting by updating `services/leaveAccrualService.js`, `utils/leaveAccrual.js`, and `server.js` so computed `earned`, `taken`, `balance`, and `manualAdjustment`/`adjustment` are surfaced consistently. 
- Update the Employee Management UI: rename `Update Leave` to `Adjust Leave`, change the modal to accept positive/negative adjustments per leave type, preview projected balances, and submit adjustments to the new endpoint via the client (`public/index.js` and `public/index.html`); also allow managers to cancel approved leave from manager lists. 
- Add test coverage for manual adjustments in `services/leaveAccrualService.test.js` and extend normalization/defaults to include `manualAdjustment`. 

### Testing

- Ran static checks with `node --check server.js && node --check public/index.js` which passed. 
- Ran unit tests with `npm test` and all tests passed (13 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a5fe9af9c83319da09edefe924e8e)