### PR TITLE
Add leave reset (Rest) settings tab with export & reset endpoints

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7394,6 +7394,7 @@
           <button type="button" class="settings-subtab-button settings-subtab-button--active" data-settings-tab="organization" role="tab" aria-selected="true">Organization</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="holidays" role="tab" aria-selected="false">Holiday Calendar</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="leaveCycle" role="tab" aria-selected="false">Leave Cycle</button>
+          <button type="button" class="settings-subtab-button" data-settings-tab="resetLeave" role="tab" aria-selected="false">Rest</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="ai" role="tab" aria-selected="false">AI Configuration</button>
           <button type="button" id="roleAssignmentTab" class="settings-subtab-button hidden" data-settings-tab="roleAssignments" role="tab" aria-selected="false">Role Assignments</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="chatWidget" role="tab" aria-selected="false">Chat Widget</button>
@@ -7498,6 +7499,63 @@
               </button>
             </form>
             <div id="leaveCycleSettingsStatus" class="settings-status text-muted"></div>
+          </div>
+        </div>
+
+
+
+        <div class="settings-subtab-panel" data-settings-tab-panel="resetLeave">
+          <div class="md-card">
+            <div class="card-title">
+              <span class="material-symbols-rounded">restart_alt</span>
+              Reset Leave for New Round
+            </div>
+            <p class="card-subtitle">Export the current leave status, then reset every employee for a new leave period with the default leave amounts below.</p>
+            <form id="resetLeaveSettingsForm" class="settings-form">
+              <div class="settings-form__fields">
+                <label class="md-label" for="resetLeaveStartDate">Start date</label>
+                <div class="md-input-wrapper">
+                  <span class="material-symbols-rounded">event</span>
+                  <input id="resetLeaveStartDate" class="md-input" type="date" required>
+                </div>
+              </div>
+              <div class="settings-form__fields">
+                <label class="md-label" for="resetLeaveEndDate">End date</label>
+                <div class="md-input-wrapper">
+                  <span class="material-symbols-rounded">event_available</span>
+                  <input id="resetLeaveEndDate" class="md-input" type="date" required>
+                </div>
+              </div>
+              <div class="settings-form__fields">
+                <label class="md-label" for="resetLeaveAnnualDefault">Annual leave for this period</label>
+                <div class="md-input-wrapper">
+                  <span class="material-symbols-rounded">beach_access</span>
+                  <input id="resetLeaveAnnualDefault" class="md-input" type="number" min="0" step="0.5" value="12" required>
+                </div>
+              </div>
+              <div class="settings-form__fields">
+                <label class="md-label" for="resetLeaveCasualDefault">Casual leave for this period</label>
+                <div class="md-input-wrapper">
+                  <span class="material-symbols-rounded">event_note</span>
+                  <input id="resetLeaveCasualDefault" class="md-input" type="number" min="0" step="0.5" value="6" required>
+                </div>
+              </div>
+              <div class="settings-form__fields">
+                <label class="md-label" for="resetLeaveMedicalDefault">Medical leave for this period</label>
+                <div class="md-input-wrapper">
+                  <span class="material-symbols-rounded">medical_services</span>
+                  <input id="resetLeaveMedicalDefault" class="md-input" type="number" min="0" step="0.5" value="12" required>
+                </div>
+              </div>
+              <div class="settings-form__fields settings-form__fields--full">
+                <div class="settings-form__help">Before resetting, a confirmation will offer an Excel download with each employee’s current balances and approved leave date history.</div>
+              </div>
+              <button type="submit" class="md-button md-button--filled md-button--small settings-form__submit">
+                <span class="material-symbols-rounded">restart_alt</span>
+                Reset leave balances
+              </button>
+            </form>
+            <div id="resetLeaveSettingsStatus" class="settings-status text-muted"></div>
           </div>
         </div>
 

--- a/public/index.js
+++ b/public/index.js
@@ -1216,6 +1216,8 @@ const settingsSubtabButtons = document.querySelectorAll('[data-settings-tab]');
 const settingsSubtabPanels = {
   organization: document.querySelector('[data-settings-tab-panel="organization"]'),
   holidays: document.querySelector('[data-settings-tab-panel="holidays"]'),
+  leaveCycle: document.querySelector('[data-settings-tab-panel="leaveCycle"]'),
+  resetLeave: document.querySelector('[data-settings-tab-panel="resetLeave"]'),
   ai: document.querySelector('[data-settings-tab-panel="ai"]'),
   roleAssignments: document.querySelector('[data-settings-tab-panel="roleAssignments"]'),
   chatWidget: document.querySelector('[data-settings-tab-panel="chatWidget"]'),
@@ -5766,6 +5768,7 @@ function loadSettingsSubtabData(name) {
   if (name === 'organization') loadOrganizationSettings();
   if (name === 'holidays') loadHolidays();
   if (name === 'leaveCycle') loadLeaveCycleSettings();
+  if (name === 'resetLeave') loadResetLeaveSettings();
   if (name === 'ai') loadAiSettingsConfig();
   if (name === 'chatWidget') loadChatWidgetSettings();
   if (name === 'postLogin') loadPostLoginSettings();
@@ -8555,6 +8558,128 @@ async function onLeaveCycleSettingsSubmit(ev) {
   }
 }
 
+
+function setResetLeaveSettingsStatus(message, type = 'info') {
+  const statusEl = document.getElementById('resetLeaveSettingsStatus');
+  if (!statusEl) return;
+  statusEl.textContent = message || '';
+  statusEl.classList.remove('settings-status--error', 'settings-status--success');
+  if (!message) {
+    statusEl.classList.add('text-muted');
+    return;
+  }
+  statusEl.classList.remove('text-muted');
+  if (type === 'error') statusEl.classList.add('settings-status--error');
+  if (type === 'success') statusEl.classList.add('settings-status--success');
+}
+
+function formatDateInputValue(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10);
+}
+
+function renderResetLeaveDefaults() {
+  const startInput = document.getElementById('resetLeaveStartDate');
+  const endInput = document.getElementById('resetLeaveEndDate');
+  const annualInput = document.getElementById('resetLeaveAnnualDefault');
+  const casualInput = document.getElementById('resetLeaveCasualDefault');
+  const medicalInput = document.getElementById('resetLeaveMedicalDefault');
+  const now = new Date();
+  const duration = Number(leaveCycleSettings?.durationMonths || 12);
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setMonth(end.getMonth() + (duration === 6 ? 6 : 12));
+  end.setDate(end.getDate() - 1);
+  if (startInput && !startInput.value) startInput.value = formatDateInputValue(start);
+  if (endInput && !endInput.value) endInput.value = formatDateInputValue(end);
+  if (annualInput && !annualInput.value) annualInput.value = '12';
+  if (casualInput && !casualInput.value) casualInput.value = '6';
+  if (medicalInput && !medicalInput.value) medicalInput.value = '12';
+}
+
+async function loadResetLeaveSettings() {
+  if (!currentUser || !isManagerRole(currentUser)) return;
+  await loadLeaveCycleSettings({ silent: true });
+  renderResetLeaveDefaults();
+}
+
+function getResetLeavePayload() {
+  return {
+    startDate: document.getElementById('resetLeaveStartDate')?.value || '',
+    endDate: document.getElementById('resetLeaveEndDate')?.value || '',
+    defaults: {
+      annual: Number(document.getElementById('resetLeaveAnnualDefault')?.value || 0),
+      casual: Number(document.getElementById('resetLeaveCasualDefault')?.value || 0),
+      medical: Number(document.getElementById('resetLeaveMedicalDefault')?.value || 0)
+    }
+  };
+}
+
+async function downloadLeaveResetExcel(payload) {
+  const params = new URLSearchParams();
+  if (payload.startDate) params.set('startDate', payload.startDate);
+  if (payload.endDate) params.set('endDate', payload.endDate);
+  const res = await apiFetch(`/settings/leave/reset/export.xls?${params.toString()}`);
+  const blob = await res.blob();
+  if (!res.ok) {
+    const message = await blob.text().catch(() => 'Unable to download leave status export.');
+    throw new Error(message || 'Unable to download leave status export.');
+  }
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `leave-status-before-reset-${new Date().toISOString().slice(0, 10)}.xls`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+async function onResetLeaveSettingsSubmit(ev) {
+  ev.preventDefault();
+  if (!currentUser || !isManagerRole(currentUser)) return;
+  const form = ev.currentTarget;
+  const submitBtn = form?.querySelector('button[type="submit"]');
+  const payload = getResetLeavePayload();
+  if (!payload.startDate || !payload.endDate) {
+    setResetLeaveSettingsStatus('Start and end dates are required.', 'error');
+    return;
+  }
+  if (new Date(payload.endDate) < new Date(payload.startDate)) {
+    setResetLeaveSettingsStatus('End date cannot be before start date.', 'error');
+    return;
+  }
+  const shouldDownload = window.confirm('Before resetting, download the current leave status in Excel? Choose OK to download, or Cancel to continue without downloading.');
+  if (submitBtn) submitBtn.disabled = true;
+  try {
+    if (shouldDownload) {
+      setResetLeaveSettingsStatus('Preparing Excel download...');
+      await downloadLeaveResetExcel(payload);
+    }
+    const confirmed = window.confirm('This will reset leave balances for all employees for the new round. Continue?');
+    if (!confirmed) {
+      setResetLeaveSettingsStatus('Reset cancelled.');
+      return;
+    }
+    setResetLeaveSettingsStatus('Resetting leave balances...');
+    const res = await apiFetch('/settings/leave/reset', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error || 'Unable to reset leave balances.');
+    setResetLeaveSettingsStatus(`Leave reset complete. Updated ${data.updated || 0} of ${data.processed || 0} employees.`, 'success');
+    if (typeof loadEmployeeSelect === 'function') loadEmployeeSelect();
+  } catch (err) {
+    console.error('Failed to reset leave balances', err);
+    setResetLeaveSettingsStatus(err.message || 'Unable to reset leave balances.', 'error');
+  } finally {
+    if (submitBtn) submitBtn.disabled = false;
+  }
+}
+
 function setChatWidgetSettingsStatus(message, type = 'info') {
   const statusEl = document.getElementById('chatWidgetSettingsStatus');
   if (!statusEl) return;
@@ -11296,6 +11421,8 @@ async function init() {
   if (organizationForm) organizationForm.addEventListener('submit', onOrganizationSettingsSubmit);
   const leaveCycleForm = document.getElementById('leaveCycleSettingsForm');
   if (leaveCycleForm) leaveCycleForm.addEventListener('submit', onLeaveCycleSettingsSubmit);
+  const resetLeaveForm = document.getElementById('resetLeaveSettingsForm');
+  if (resetLeaveForm) resetLeaveForm.addEventListener('submit', onResetLeaveSettingsSubmit);
   const organizationLogoInput = document.getElementById('organizationLogoFile');
   if (organizationLogoInput) organizationLogoInput.addEventListener('change', onOrganizationLogoFileChange);
 

--- a/server.js
+++ b/server.js
@@ -5326,6 +5326,80 @@ init().then(async () => {
     }
   });
 
+
+  function escapeXml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  function excelCell(value, type = 'String') {
+    const safeType = type === 'Number' ? 'Number' : 'String';
+    const safeValue = safeType === 'Number' && Number.isFinite(Number(value)) ? Number(value) : escapeXml(value);
+    return `<Cell><Data ss:Type="${safeType}">${safeValue}</Data></Cell>`;
+  }
+
+  function excelRow(values) {
+    return `<Row>${values.map(value => {
+      if (value && typeof value === 'object' && 'value' in value) return excelCell(value.value, value.type);
+      return excelCell(value);
+    }).join('')}</Row>`;
+  }
+
+  function normalizeResetLeavePayload(body = {}) {
+    const startDate = new Date(body.startDate);
+    const endDate = new Date(body.endDate);
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+      return { error: 'Valid start and end dates are required.' };
+    }
+    if (endDate < startDate) return { error: 'End date cannot be before start date.' };
+    const defaults = body.defaults && typeof body.defaults === 'object' ? body.defaults : {};
+    const normalizedDefaults = {};
+    for (const type of SUPPORTED_LEAVE_TYPES) {
+      const value = Number(defaults[type]);
+      if (!Number.isFinite(value) || value < 0) {
+        return { error: `Enter a valid ${type} leave amount.` };
+      }
+      normalizedDefaults[type] = Math.round(value * 10) / 10;
+    }
+    startDate.setHours(0, 0, 0, 0);
+    endDate.setHours(23, 59, 59, 999);
+    return { startDate, endDate, defaults: normalizedDefaults };
+  }
+
+  function buildLeaveResetWorkbook(employees = [], applications = [], startDate = null, endDate = null) {
+    const approvedApps = applications.filter(app => app && app.status === 'approved');
+    const summaryRows = [excelRow(['Employee ID', 'Name', 'Title', 'Location', 'Annual Balance', 'Annual Taken', 'Casual Balance', 'Casual Taken', 'Medical Balance', 'Medical Taken', 'Cycle Start', 'Cycle End'])];
+    employees.forEach(emp => {
+      const balances = emp.leaveBalances || {};
+      summaryRows.push(excelRow([
+        emp.id || '', emp.name || '', emp.Title || emp.title || '', emp['Country / City'] || emp.location || '',
+        { value: balances.annual?.balance || 0, type: 'Number' }, { value: balances.annual?.taken || 0, type: 'Number' },
+        { value: balances.casual?.balance || 0, type: 'Number' }, { value: balances.casual?.taken || 0, type: 'Number' },
+        { value: balances.medical?.balance || 0, type: 'Number' }, { value: balances.medical?.taken || 0, type: 'Number' },
+        balances.cycleStart ? new Date(balances.cycleStart).toISOString().slice(0, 10) : '',
+        balances.cycleEnd ? new Date(balances.cycleEnd).toISOString().slice(0, 10) : ''
+      ]));
+    });
+    const historyRows = [excelRow(['Employee ID', 'Name', 'Leave Type', 'From', 'To', 'Days', 'Reason', 'Approved By', 'Approved At'])];
+    approvedApps.forEach(app => {
+      const from = new Date(app.from);
+      const to = new Date(app.to);
+      if (startDate && to < startDate) return;
+      if (endDate && from > endDate) return;
+      const emp = employees.find(e => e.id == app.employeeId) || {};
+      historyRows.push(excelRow([
+        app.employeeId || '', emp.name || '', app.type || '', app.from || '', app.to || '',
+        { value: getLeaveDaysInRange(app, startDate, endDate) || getLeaveDays(app), type: 'Number' },
+        app.reason || '', app.approvedBy || '', app.approvedAt || ''
+      ]));
+    });
+    return `<?xml version="1.0"?><?mso-application progid="Excel.Sheet"?><Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"><Worksheet ss:Name="Current Balances"><Table>${summaryRows.join('')}</Table></Worksheet><Worksheet ss:Name="Leave History"><Table>${historyRows.join('')}</Table></Worksheet></Workbook>`;
+  }
+
   app.put('/settings/leave', authRequired, managerOnly, async (req, res) => {
     try {
       const requestedDuration = Number(req.body?.durationMonths);
@@ -5347,6 +5421,62 @@ init().then(async () => {
     } catch (err) {
       console.error('Failed to save leave settings', err);
       res.status(500).json({ error: 'Unable to save leave settings.' });
+    }
+  });
+
+
+
+  app.get('/settings/leave/reset/export.xls', authRequired, managerOnly, async (req, res) => {
+    try {
+      await db.read();
+      const requestedStartDate = req.query.startDate ? new Date(req.query.startDate) : null;
+      const requestedEndDate = req.query.endDate ? new Date(req.query.endDate) : null;
+      const startDate = requestedStartDate && !Number.isNaN(requestedStartDate.getTime()) ? requestedStartDate : null;
+      const endDate = requestedEndDate && !Number.isNaN(requestedEndDate.getTime()) ? requestedEndDate : null;
+      const workbook = buildLeaveResetWorkbook(db.data.employees || [], db.data.applications || [], startDate, endDate);
+      res.setHeader('Content-Type', 'application/vnd.ms-excel; charset=utf-8');
+      res.setHeader('Content-Disposition', `attachment; filename="leave-status-before-reset-${new Date().toISOString().slice(0, 10)}.xls"`);
+      res.send(workbook);
+    } catch (err) {
+      console.error('Failed to export leave reset workbook', err);
+      res.status(500).send('Unable to export leave status.');
+    }
+  });
+
+  app.post('/settings/leave/reset', authRequired, managerOnly, async (req, res) => {
+    try {
+      const parsed = normalizeResetLeavePayload(req.body || {});
+      if (parsed.error) return res.status(400).json({ error: parsed.error });
+      await db.read();
+      db.data.employees = Array.isArray(db.data.employees) ? db.data.employees : [];
+      let updated = 0;
+      db.data.employees.forEach(emp => {
+        const balances = cloneDefaultLeaveBalances();
+        SUPPORTED_LEAVE_TYPES.forEach(type => {
+          const allocation = parsed.defaults[type];
+          balances[type] = {
+            ...DEFAULT_LEAVE_BALANCES[type],
+            yearlyAllocation: allocation,
+            monthlyAccrual: allocation / 12,
+            accrued: allocation,
+            taken: 0,
+            balance: allocation,
+            manualAdjustment: 0
+          };
+        });
+        balances.cycleStart = parsed.startDate;
+        balances.cycleEnd = parsed.endDate;
+        balances.lastAccrualRun = null;
+        balances.cycleDurationMonths = Math.max(1, Math.round((parsed.endDate - parsed.startDate) / (1000 * 60 * 60 * 24 * 30)));
+        const changed = JSON.stringify(emp.leaveBalances || {}) !== JSON.stringify(balances);
+        emp.leaveBalances = balances;
+        if (changed) updated += 1;
+      });
+      await db.write();
+      res.json({ processed: db.data.employees.length, updated, startDate: parsed.startDate, endDate: parsed.endDate, defaults: parsed.defaults });
+    } catch (err) {
+      console.error('Failed to reset leave balances', err);
+      res.status(500).json({ error: 'Unable to reset leave balances.' });
     }
   });
 


### PR DESCRIPTION
### Motivation
- Provide a manager-facing workflow to start a new leave round by resetting employee leave balances to configured defaults. 
- Allow exporting the current leave status and approved leave history so administrators can archive records before resetting. 
- Reuse existing leave-cycle concepts (start/end dates, per-type allocations) and enforce manager-only access for safety. 

### Description
- Added a new settings subtab (labelled `Rest`) in `public/index.html` with inputs for `Start date`, `End date`, and default amounts for `annual`, `casual`, and `medical` leave. 
- Wired UI logic in `public/index.js` to register the tab, render sensible defaults based on the configured leave cycle, validate inputs, prompt the user to download the current leave status, and call the backend reset API; the client downloads `leave-status-before-reset-<date>.xls` when requested. 
- Implemented manager-only backend endpoints in `server.js`: `GET /settings/leave/reset/export.xls` to return an Excel-compatible XML workbook containing current balances and approved leave history, and `POST /settings/leave/reset` to validate payload and reset all employees’ `leaveBalances` to the supplied defaults and cycle dates. 
- The server export builds a two-sheet workbook (`Current Balances` and `Leave History`) (XML Spreadsheet) and the reset operation normalizes defaults, updates `cycleStart`/`cycleEnd`, recomputes per-type accrual fields, writes to the DB, and returns a summary of `processed` and `updated` counts. 

### Testing
- Performed syntax checks with `node --check server.js` and `node --check public/index.js`, both succeeded. 
- Ran the test suite with `npm test`, all existing leave accrual tests passed (`13` tests, `0` failures). 
- Verified the new client flow triggers the export endpoint and the backend endpoints return expected responses during local runs (no automated failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42009f70708331b708b59ca330e87d)