### PR TITLE
Persist active leave cycle on reset and scope reports to active cycle

### DIFF
--- a/server.js
+++ b/server.js
@@ -5309,6 +5309,8 @@ init().then(async () => {
     const settings = getLeaveCycleSettings(stored || {});
     return {
       durationMonths: settings.durationMonths,
+      activeCycleStart: settings.activeCycleStart,
+      activeCycleEnd: settings.activeCycleEnd,
       supportedDurations: SUPPORTED_CYCLE_DURATIONS,
       defaultDurationMonths: DEFAULT_LEAVE_CYCLE_DURATION_MONTHS,
       negativeBalanceLimits: NEGATIVE_BALANCE_LIMITS
@@ -5410,7 +5412,13 @@ init().then(async () => {
 
       await db.read();
       db.data.settings = db.data.settings && typeof db.data.settings === 'object' ? db.data.settings : {};
-      db.data.settings.leaveCycle = { durationMonths };
+      const previousLeaveCycle = db.data.settings.leaveCycle && typeof db.data.settings.leaveCycle === 'object'
+        ? db.data.settings.leaveCycle
+        : {};
+      db.data.settings.leaveCycle = {
+        ...previousLeaveCycle,
+        durationMonths
+      };
       await db.write();
 
       const recalculation = await recalculateLeaveBalancesForCycle(new Date());
@@ -5448,6 +5456,21 @@ init().then(async () => {
       const parsed = normalizeResetLeavePayload(req.body || {});
       if (parsed.error) return res.status(400).json({ error: parsed.error });
       await db.read();
+      db.data.settings = db.data.settings && typeof db.data.settings === 'object' ? db.data.settings : {};
+      const previousLeaveCycle = db.data.settings.leaveCycle && typeof db.data.settings.leaveCycle === 'object'
+        ? db.data.settings.leaveCycle
+        : {};
+      const cycleDurationMonths = Math.max(1, Math.round(
+        (parsed.endDate.getFullYear() - parsed.startDate.getFullYear()) * 12 +
+        (parsed.endDate.getMonth() - parsed.startDate.getMonth()) + 1
+      ));
+      db.data.settings.leaveCycle = {
+        ...previousLeaveCycle,
+        durationMonths: normalizeCycleDurationMonths(cycleDurationMonths),
+        activeCycleStart: parsed.startDate,
+        activeCycleEnd: parsed.endDate,
+        lastManualResetAt: new Date().toISOString()
+      };
       db.data.employees = Array.isArray(db.data.employees) ? db.data.employees : [];
       let updated = 0;
       db.data.employees.forEach(emp => {
@@ -5458,22 +5481,22 @@ init().then(async () => {
             ...DEFAULT_LEAVE_BALANCES[type],
             yearlyAllocation: allocation,
             monthlyAccrual: allocation / 12,
-            accrued: allocation,
+            accrued: 0,
             taken: 0,
-            balance: allocation,
+            balance: 0,
             manualAdjustment: 0
           };
         });
         balances.cycleStart = parsed.startDate;
         balances.cycleEnd = parsed.endDate;
         balances.lastAccrualRun = null;
-        balances.cycleDurationMonths = Math.max(1, Math.round((parsed.endDate - parsed.startDate) / (1000 * 60 * 60 * 24 * 30)));
+        balances.cycleDurationMonths = cycleDurationMonths;
         const changed = JSON.stringify(emp.leaveBalances || {}) !== JSON.stringify(balances);
         emp.leaveBalances = balances;
         if (changed) updated += 1;
       });
       await db.write();
-      res.json({ processed: db.data.employees.length, updated, startDate: parsed.startDate, endDate: parsed.endDate, defaults: parsed.defaults });
+      res.json({ processed: db.data.employees.length, updated, startDate: parsed.startDate, endDate: parsed.endDate, defaults: parsed.defaults, cycleDurationMonths });
     } catch (err) {
       console.error('Failed to reset leave balances', err);
       res.status(500).json({ error: 'Unable to reset leave balances.' });
@@ -5984,12 +6007,18 @@ init().then(async () => {
     res.json({ success: true });
   });
 
+  function getActiveLeaveReportRange(settings = {}) {
+    const cycle = getCurrentCycleRange(new Date(), getLeaveCycleSettings(settings));
+    return { startDate: cycle.start, endDate: cycle.end };
+  }
+
   // ---- LEAVE REPORT ----
   app.get('/leave-report', authRequired, managerOnly, async (req, res) => {
     await db.read();
     const { start, end } = req.query;
-    const startDate = start ? new Date(start) : null;
-    const endDate = end ? new Date(end) : null;
+    const activeRange = getActiveLeaveReportRange(db.data.settings || {});
+    const startDate = start ? new Date(start) : activeRange.startDate;
+    const endDate = end ? new Date(end) : activeRange.endDate;
     const emps = db.data.employees || [];
     const apps = db.data.applications || [];
 
@@ -6030,7 +6059,15 @@ init().then(async () => {
   app.get('/leave-report/export', authRequired, managerOnly, async (req, res) => {
     await db.read();
     const emps = db.data.employees || [];
-    const apps = (db.data.applications || []).filter(a => a.status === 'approved');
+    const activeRange = getActiveLeaveReportRange(db.data.settings || {});
+    const apps = (db.data.applications || []).filter(a => {
+      if (!a || a.status !== 'approved') return false;
+      const from = new Date(a.from);
+      const to = new Date(a.to);
+      if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return false;
+      if (to < activeRange.startDate || from > activeRange.endDate) return false;
+      return true;
+    });
 
     function escapeCsv(value) {
       if (!value) return '';
@@ -6042,10 +6079,13 @@ init().then(async () => {
     for (const app of apps) {
       const emp = emps.find(e => e.id == app.employeeId) || {};
       const name = emp.name || '';
-      const start = new Date(app.from);
-      const end = new Date(app.to);
+      const appStart = new Date(app.from);
+      const appEnd = new Date(app.to);
+      const start = appStart < activeRange.startDate ? new Date(activeRange.startDate) : appStart;
+      const end = appEnd > activeRange.endDate ? new Date(activeRange.endDate) : appEnd;
       if (app.halfDay) {
-        const dateStr = start.toISOString().split('T')[0];
+        if (appStart < activeRange.startDate || appStart > activeRange.endDate) continue;
+        const dateStr = appStart.toISOString().split('T')[0];
         const period = app.halfDayType || app.halfDayPeriod || '';
         const type = `${app.type} (Half Day${period ? ' ' + period : ''})`;
         rows.push({ name, date: dateStr, type });
@@ -6070,8 +6110,9 @@ init().then(async () => {
   app.get('/leave-calendar', authRequired, managerOnly, async (req, res) => {
     await db.read();
     const { start, end } = req.query;
-    const startDate = start ? new Date(start) : null;
-    const endDate = end ? new Date(end) : null;
+    const activeRange = getActiveLeaveReportRange(db.data.settings || {});
+    const startDate = start ? new Date(start) : activeRange.startDate;
+    const endDate = end ? new Date(end) : activeRange.endDate;
     const emps = db.data.employees || [];
     const apps = (db.data.applications || []).filter(a => a.status === 'approved');
     const map = {};

--- a/services/leaveAccrualService.js
+++ b/services/leaveAccrualService.js
@@ -26,11 +26,25 @@ function normalizeCycleDurationMonths(value) {
     : DEFAULT_LEAVE_CYCLE_DURATION_MONTHS;
 }
 
+function parseCycleBoundary(value, endOfDay = false) {
+  if (!value) return null;
+  const date = value instanceof Date ? new Date(value) : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  date.setHours(endOfDay ? 23 : 0, endOfDay ? 59 : 0, endOfDay ? 59 : 0, endOfDay ? 999 : 0);
+  return date;
+}
+
 function getLeaveCycleSettings(settings = {}) {
   const source = settings?.leaveCycle && typeof settings.leaveCycle === 'object'
     ? settings.leaveCycle
     : settings;
-  return { durationMonths: normalizeCycleDurationMonths(source?.durationMonths) };
+  const activeCycleStart = parseCycleBoundary(source?.activeCycleStart || source?.cycleStart);
+  const activeCycleEnd = parseCycleBoundary(source?.activeCycleEnd || source?.cycleEnd, true);
+  return {
+    durationMonths: normalizeCycleDurationMonths(source?.durationMonths),
+    activeCycleStart,
+    activeCycleEnd
+  };
 }
 
 function getEmployeeEntitlement(employee, type) {
@@ -111,6 +125,16 @@ function startOfDay(date) {
 
 function getCurrentCycleRange(now = new Date(), options = {}) {
   const base = new Date(now);
+  const activeCycleStart = typeof options === 'object' ? parseCycleBoundary(options?.activeCycleStart || options?.cycleStart) : null;
+  const activeCycleEnd = typeof options === 'object' ? parseCycleBoundary(options?.activeCycleEnd || options?.cycleEnd, true) : null;
+  if (activeCycleStart && activeCycleEnd && activeCycleEnd >= activeCycleStart && base >= activeCycleStart && base <= activeCycleEnd) {
+    const durationMonths = Math.max(1, Math.round(
+      (activeCycleEnd.getFullYear() - activeCycleStart.getFullYear()) * 12 +
+      (activeCycleEnd.getMonth() - activeCycleStart.getMonth()) + 1
+    ));
+    return { start: activeCycleStart, end: activeCycleEnd, durationMonths };
+  }
+
   const durationMonths = normalizeCycleDurationMonths(
     typeof options === 'number' ? options : options?.durationMonths
   );

--- a/services/leaveAccrualService.test.js
+++ b/services/leaveAccrualService.test.js
@@ -197,3 +197,22 @@ test('Negative balance limits are configured per leave type', () => {
   assert.equal(getNegativeBalanceLimit('medical'), 2);
   assert.equal(getNegativeBalanceLimit('casual'), 1);
 });
+
+test('Manual reset active cycle ignores prior cycle leave records', () => {
+  const asOfDate = new Date('2026-06-29');
+  const cycleRange = getCurrentCycleRange(asOfDate, {
+    durationMonths: 12,
+    activeCycleStart: new Date('2026-06-01'),
+    activeCycleEnd: new Date('2027-05-31')
+  });
+  const employee = createEmployee(new Date('2020-01-01'));
+  const apps = [
+    leaveApplication(employee.id, 'annual', '2026-05-20', '2026-05-21'),
+    leaveApplication(employee.id, 'annual', '2026-06-15', '2026-06-15')
+  ];
+
+  const { balances } = buildEmployeeLeaveState(employee, apps, { cycleRange, asOfDate, holidays: [] });
+
+  assert.equal(cycleRange.start.toISOString().slice(0, 10), '2026-06-01');
+  assert.equal(balances.annual.taken, 1);
+});


### PR DESCRIPTION
### Motivation
- Allow a manual leave reset to keep old application history in the database but hide previous-period balances from the UI by making the reset range the active cycle for reporting and accruals.
- Ensure everyone starts the new cycle with zeroed balances and then accrues normally for the running period.

### Description
- Add `parseCycleBoundary` and include `activeCycleStart` / `activeCycleEnd` in `getLeaveCycleSettings` so an explicitly set manual cycle is recognized by the accrual logic in `services/leaveAccrualService.js`.
- Make `getCurrentCycleRange` favour an active/manual cycle when the current date falls inside it so accrual and taken calculations only consider the running period.
- Persist active cycle metadata (`activeCycleStart`, `activeCycleEnd`, `cycleDurationMonths`, `lastManualResetAt`) when updating leave settings or performing a manual reset, and reset each employee's `accrued`, `taken`, and `balance` to `0` while preserving historical applications in `server.js`.
- Default leave report endpoints (`/leave-report`, `/leave-report/export`, `/leave-calendar`) to the active cycle range so exported reports and calendar data only show the current period unless explicit `start`/`end` query params are provided.
- Add a regression test `Manual reset active cycle ignores prior cycle leave records` to `services/leaveAccrualService.test.js` verifying prior-period approved leaves are ignored for the new active cycle.

### Testing
- Ran `npm test` (Node built-in test runner via `node --test`) and all tests passed (14 tests, 0 failures).
- Performed syntax checks with `node --check server.js` and `node --check services/leaveAccrualService.js`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4206d4832883319f6880b1c7a7bee2)