### PR TITLE
Fix leave reset balance recalculation

### DIFF
--- a/server.js
+++ b/server.js
@@ -5464,12 +5464,13 @@ init().then(async () => {
         (parsed.endDate.getFullYear() - parsed.startDate.getFullYear()) * 12 +
         (parsed.endDate.getMonth() - parsed.startDate.getMonth()) + 1
       ));
+      const resetTimestamp = new Date().toISOString();
       db.data.settings.leaveCycle = {
         ...previousLeaveCycle,
         durationMonths: normalizeCycleDurationMonths(cycleDurationMonths),
         activeCycleStart: parsed.startDate,
         activeCycleEnd: parsed.endDate,
-        lastManualResetAt: new Date().toISOString()
+        lastManualResetAt: resetTimestamp
       };
       db.data.employees = Array.isArray(db.data.employees) ? db.data.employees : [];
       let updated = 0;
@@ -5490,6 +5491,7 @@ init().then(async () => {
         balances.cycleStart = parsed.startDate;
         balances.cycleEnd = parsed.endDate;
         balances.lastAccrualRun = null;
+        balances.lastManualResetAt = resetTimestamp;
         balances.cycleDurationMonths = cycleDurationMonths;
         const changed = JSON.stringify(emp.leaveBalances || {}) !== JSON.stringify(balances);
         emp.leaveBalances = balances;
@@ -6679,7 +6681,8 @@ init().then(async () => {
       from: normalizedFrom,
       to: normalizedTo,
       reason: reason || '',
-      status: 'pending'
+      status: 'pending',
+      createdAt: new Date().toISOString()
     };
 
     if (halfDay) {

--- a/services/leaveAccrualService.js
+++ b/services/leaveAccrualService.js
@@ -151,6 +151,36 @@ function getCurrentCycleRange(now = new Date(), options = {}) {
   return { start, end, durationMonths };
 }
 
+
+function parseDateValue(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? new Date(value) : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getFirstDayOfNextMonth(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null;
+  return new Date(date.getFullYear(), date.getMonth() + 1, 1);
+}
+
+function getApplicationCreatedDate(app) {
+  const created = parseDateValue(app?.createdAt || app?.submittedAt || app?.requestedAt);
+  if (created) return created;
+  const numericId = Number(app?.id);
+  if (Number.isFinite(numericId) && numericId > 946684800000) {
+    const fromId = new Date(numericId);
+    if (!Number.isNaN(fromId.getTime())) return fromId;
+  }
+  return null;
+}
+
+function isApplicationBeforeManualReset(app, manualResetAt) {
+  const resetDate = parseDateValue(manualResetAt);
+  if (!resetDate) return false;
+  const createdDate = getApplicationCreatedDate(app);
+  return !createdDate || createdDate < resetDate;
+}
+
 function getMonthStart(date) {
   return new Date(date.getFullYear(), date.getMonth(), 1);
 }
@@ -395,7 +425,7 @@ function getLeaveDaysWithin(app, startDate, endDate, holidaySet = new Set()) {
   return days;
 }
 
-function calculateLeaveTakenForEmployee(employeeId, applications, cycleRange, asOfDate, holidays) {
+function calculateLeaveTakenForEmployee(employeeId, applications, cycleRange, asOfDate, holidays, options = {}) {
   const totals = { annual: 0, casual: 0, medical: 0 };
   if (!Array.isArray(applications)) return totals;
 
@@ -410,6 +440,7 @@ function calculateLeaveTakenForEmployee(employeeId, applications, cycleRange, as
 
   applications.forEach(app => {
     if (!app || app.employeeId != employeeId) return;
+    if (isApplicationBeforeManualReset(app, options.manualResetAt)) return;
     const status = String(app.status || '').toLowerCase();
     if (status !== 'approved') return;
     const leaveType = String(app.type || '').toLowerCase();
@@ -433,13 +464,20 @@ function buildEmployeeLeaveState(employee, applications, options = {}) {
   const cycleRange = options.cycleRange || getCurrentCycleRange(asOfDate, settings);
   const holidays = options.holidays || [];
 
-  const accrued = calculateAccruedLeaveForEmployee(employee, cycleRange, asOfDate);
+  const manualResetAt = parseDateValue(employee?.leaveBalances?.lastManualResetAt);
+  const accrualResumeDate = getFirstDayOfNextMonth(manualResetAt);
+  const accrualCycleRange = accrualResumeDate && accrualResumeDate > cycleRange.start
+    ? { ...cycleRange, start: accrualResumeDate }
+    : cycleRange;
+
+  const accrued = calculateAccruedLeaveForEmployee(employee, accrualCycleRange, asOfDate);
   const taken = calculateLeaveTakenForEmployee(
     employee?.id,
     applications,
     cycleRange,
     asOfDate,
-    holidays
+    holidays,
+    { manualResetAt }
   );
 
   const balances = cloneDefaultLeaveBalances();
@@ -468,6 +506,9 @@ function buildEmployeeLeaveState(employee, applications, options = {}) {
   balances.cycleStart = cycleRange.start;
   balances.cycleEnd = cycleRange.end;
   balances.lastAccrualRun = asOfDate;
+  if (manualResetAt) {
+    balances.lastManualResetAt = manualResetAt.toISOString();
+  }
   balances.cycleDurationMonths = cycleRange.durationMonths || settings.durationMonths;
 
   return { balances, accrued, taken, cycleRange };

--- a/services/leaveAccrualService.test.js
+++ b/services/leaveAccrualService.test.js
@@ -131,6 +131,53 @@ test('Negative balances are produced when leave exceeds accrual', () => {
   assert(balances.annual.balance < 0);
 });
 
+
+test('Manual reset keeps balances at zero until the next accrual month and ignores prior applications', () => {
+  const asOfDate = new Date('2025-06-15T12:00:00Z');
+  const resetAt = new Date('2025-06-15T10:00:00Z').toISOString();
+  const employee = {
+    ...createEmployee(new Date('2020-01-01')),
+    leaveBalances: {
+      annual: { ...DEFAULT_LEAVE_BALANCES.annual, balance: 0, accrued: 0, taken: 0 },
+      casual: { ...DEFAULT_LEAVE_BALANCES.casual, balance: 0, accrued: 0, taken: 0 },
+      medical: { ...DEFAULT_LEAVE_BALANCES.medical, balance: 0, accrued: 0, taken: 0 },
+      lastManualResetAt: resetAt
+    }
+  };
+  const apps = [
+    { ...leaveApplication(employee.id, 'annual', '2025-06-10', '2025-06-11'), createdAt: '2025-06-14T09:00:00Z' },
+    { ...leaveApplication(employee.id, 'casual', '2025-06-12', '2025-06-12'), id: Date.parse('2025-06-14T09:00:00Z') }
+  ];
+
+  const balances = runState(employee, apps, asOfDate);
+
+  assert.equal(balances.annual.balance, 0);
+  assert.equal(balances.casual.balance, 0);
+  assert.equal(balances.medical.balance, 0);
+  assert.equal(balances.annual.taken, 0);
+  assert.equal(balances.lastManualResetAt, resetAt);
+});
+
+test('Applications submitted after a manual reset are deducted', () => {
+  const asOfDate = new Date('2025-07-31T12:00:00Z');
+  const resetAt = new Date('2025-06-15T10:00:00Z').toISOString();
+  const employee = {
+    ...createEmployee(new Date('2020-01-01')),
+    leaveBalances: {
+      annual: { ...DEFAULT_LEAVE_BALANCES.annual, balance: 0, accrued: 0, taken: 0 },
+      lastManualResetAt: resetAt
+    }
+  };
+  const apps = [
+    { ...leaveApplication(employee.id, 'annual', '2025-07-03', '2025-07-03'), createdAt: '2025-06-16T09:00:00Z' }
+  ];
+
+  const balances = runState(employee, apps, asOfDate);
+
+  assert.equal(balances.annual.taken, 1);
+  assert.equal(balances.annual.balance, roundToOneDecimal((10 / 12) - 1));
+});
+
 test('Recalculation is idempotent for the same inputs', () => {
   const asOfDate = new Date('2025-06-30');
   const employee = createEmployee(new Date('2024-07-01'));


### PR DESCRIPTION
### Motivation
- Manual leave resets were not persisting a reset timestamp or excluding prior approved applications, causing recalculation to reapply accruals and old leaves and produce non-zero balances immediately after a reset. 
- The goal is to keep balances at zero immediately after a manual reset and only apply accruals and post-reset leave records moving forward.

### Description
- Persist a `lastManualResetAt` timestamp during the reset flow and on each employee’s `leaveBalances` so recalculation can detect manual resets (`server.js`).
- Add `createdAt` to newly created leave applications so application submission time can be used for reset-aware logic (`server.js`).
- Introduce helper functions `parseDateValue`, `getFirstDayOfNextMonth`, `getApplicationCreatedDate`, and `isApplicationBeforeManualReset`, and change `calculateLeaveTakenForEmployee` to accept an `options.manualResetAt` flag so applications created before a manual reset are ignored (`services/leaveAccrualService.js`).
- Change accrual calculation to resume from the first day of the month after a manual reset so employees don’t immediately receive prorated accrual on the reset day (`services/leaveAccrualService.js`).
- Add regression tests that verify balances remain zero immediately after a manual reset and that only post-reset applications are deducted (`services/leaveAccrualService.test.js`).

### Testing
- Ran the test suite with `npm test` (which invokes `node --test`) and all tests passed: 16/16 tests succeeded, including the new manual-reset regression tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42092302b083318451c3e85912a047)