### PR TITLE
Add leave reset cleanup action and rename Reset tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "node --test",
-    "backfill:ai-interview-mode": "node scripts/backfillAiInterviewMode.js"
+    "backfill:ai-interview-mode": "node scripts/backfillAiInterviewMode.js",
+    "clean:leave-table": "node scripts/cleanLeaveTableForReset.js"
   },
   "keywords": [],
   "author": "",

--- a/public/index.html
+++ b/public/index.html
@@ -7394,7 +7394,7 @@
           <button type="button" class="settings-subtab-button settings-subtab-button--active" data-settings-tab="organization" role="tab" aria-selected="true">Organization</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="holidays" role="tab" aria-selected="false">Holiday Calendar</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="leaveCycle" role="tab" aria-selected="false">Leave Cycle</button>
-          <button type="button" class="settings-subtab-button" data-settings-tab="resetLeave" role="tab" aria-selected="false">Rest</button>
+          <button type="button" class="settings-subtab-button" data-settings-tab="resetLeave" role="tab" aria-selected="false">Reset</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="ai" role="tab" aria-selected="false">AI Configuration</button>
           <button type="button" id="roleAssignmentTab" class="settings-subtab-button hidden" data-settings-tab="roleAssignments" role="tab" aria-selected="false">Role Assignments</button>
           <button type="button" class="settings-subtab-button" data-settings-tab="chatWidget" role="tab" aria-selected="false">Chat Widget</button>
@@ -7555,6 +7555,13 @@
                 Reset leave balances
               </button>
             </form>
+            <div class="settings-form__fields settings-form__fields--full">
+              <div class="settings-form__help">If old leave rows are still showing non-zero taken values after a reset, clear the leave table to remove historical leave applications and force all employee leave balances to 0 / 0 / 0.</div>
+            </div>
+            <button type="button" id="cleanLeaveTableBtn" class="md-button md-button--outlined md-button--small settings-form__submit">
+              <span class="material-symbols-rounded">delete_sweep</span>
+              Clean leave table for reset
+            </button>
             <div id="resetLeaveSettingsStatus" class="settings-status text-muted"></div>
           </div>
         </div>

--- a/public/index.js
+++ b/public/index.js
@@ -8680,6 +8680,30 @@ async function onResetLeaveSettingsSubmit(ev) {
   }
 }
 
+async function onCleanLeaveTableForReset() {
+  if (!currentUser || !isManagerRole(currentUser)) return;
+  const button = document.getElementById('cleanLeaveTableBtn');
+  const confirmed = window.confirm('This will permanently delete all leave application rows and set annual, casual, and medical balances/taken/accrued values to 0 for every employee. Continue?');
+  if (!confirmed) {
+    setResetLeaveSettingsStatus('Clean leave table cancelled.');
+    return;
+  }
+  if (button) button.disabled = true;
+  try {
+    setResetLeaveSettingsStatus('Cleaning leave table for reset...');
+    const res = await apiFetch('/settings/leave/reset/clean-table', { method: 'POST' });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error || 'Unable to clean leave table.');
+    setResetLeaveSettingsStatus(`Leave table cleaned. Removed ${data.removedApplications || 0} leave rows and reset ${data.updatedEmployees || 0} employees to 0 / 0 / 0.`, 'success');
+    if (typeof loadEmployeeSelect === 'function') loadEmployeeSelect();
+  } catch (err) {
+    console.error('Failed to clean leave table for reset', err);
+    setResetLeaveSettingsStatus(err.message || 'Unable to clean leave table.', 'error');
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
 function setChatWidgetSettingsStatus(message, type = 'info') {
   const statusEl = document.getElementById('chatWidgetSettingsStatus');
   if (!statusEl) return;
@@ -11423,6 +11447,8 @@ async function init() {
   if (leaveCycleForm) leaveCycleForm.addEventListener('submit', onLeaveCycleSettingsSubmit);
   const resetLeaveForm = document.getElementById('resetLeaveSettingsForm');
   if (resetLeaveForm) resetLeaveForm.addEventListener('submit', onResetLeaveSettingsSubmit);
+  const cleanLeaveTableBtn = document.getElementById('cleanLeaveTableBtn');
+  if (cleanLeaveTableBtn) cleanLeaveTableBtn.addEventListener('click', onCleanLeaveTableForReset);
   const organizationLogoInput = document.getElementById('organizationLogoFile');
   if (organizationLogoInput) organizationLogoInput.addEventListener('change', onOrganizationLogoFileChange);
 

--- a/scripts/cleanLeaveTableForReset.js
+++ b/scripts/cleanLeaveTableForReset.js
@@ -1,0 +1,82 @@
+const { db } = require('../db');
+const {
+  DEFAULT_LEAVE_BALANCES,
+  SUPPORTED_LEAVE_TYPES,
+  cloneDefaultLeaveBalances,
+  getLeaveCycleSettings
+} = require('../services/leaveAccrualService');
+
+async function cleanLeaveTableForReset() {
+  await db.read();
+  db.data = db.data || {};
+  db.data.applications = Array.isArray(db.data.applications) ? db.data.applications : [];
+  db.data.employees = Array.isArray(db.data.employees) ? db.data.employees : [];
+  db.data.settings = db.data.settings && typeof db.data.settings === 'object' ? db.data.settings : {};
+
+  const removedApplications = db.data.applications.length;
+  db.data.applications = [];
+
+  const resetTimestamp = new Date().toISOString();
+  let updatedEmployees = 0;
+
+  db.data.employees.forEach(employee => {
+    if (!employee || typeof employee !== 'object') return;
+
+    const balances = cloneDefaultLeaveBalances();
+    SUPPORTED_LEAVE_TYPES.forEach(type => {
+      const previous = employee.leaveBalances?.[type] && typeof employee.leaveBalances[type] === 'object'
+        ? employee.leaveBalances[type]
+        : {};
+      const yearlyAllocation = Number.isFinite(Number(previous.yearlyAllocation))
+        ? Number(previous.yearlyAllocation)
+        : DEFAULT_LEAVE_BALANCES[type].yearlyAllocation;
+
+      balances[type] = {
+        ...DEFAULT_LEAVE_BALANCES[type],
+        yearlyAllocation,
+        monthlyAccrual: yearlyAllocation / 12,
+        accrued: 0,
+        taken: 0,
+        balance: 0,
+        manualAdjustment: 0
+      };
+    });
+
+    balances.cycleStart = employee.leaveBalances?.cycleStart || null;
+    balances.cycleEnd = employee.leaveBalances?.cycleEnd || null;
+    balances.lastAccrualRun = null;
+    balances.lastManualResetAt = resetTimestamp;
+    balances.cycleDurationMonths = employee.leaveBalances?.cycleDurationMonths || getLeaveCycleSettings(db.data.settings?.leaveCycle).durationMonths;
+
+    const changed = JSON.stringify(employee.leaveBalances || {}) !== JSON.stringify(balances);
+    employee.leaveBalances = balances;
+    if (changed) updatedEmployees += 1;
+  });
+
+  db.data.settings.leaveCycle = db.data.settings.leaveCycle && typeof db.data.settings.leaveCycle === 'object'
+    ? { ...db.data.settings.leaveCycle, lastManualResetAt: resetTimestamp }
+    : { lastManualResetAt: resetTimestamp };
+
+  await db.write();
+
+  return {
+    removedApplications,
+    updatedEmployees,
+    processedEmployees: db.data.employees.length,
+    resetTimestamp
+  };
+}
+
+module.exports = { cleanLeaveTableForReset };
+
+if (require.main === module) {
+  cleanLeaveTableForReset()
+    .then(result => {
+      console.log(`Leave table cleaned: removed ${result.removedApplications} leave rows and reset ${result.updatedEmployees}/${result.processedEmployees} employees to 0 / 0 / 0.`);
+      process.exit(0);
+    })
+    .catch(error => {
+      console.error('Failed to clean leave table for reset:', error);
+      process.exit(1);
+    });
+}

--- a/server.js
+++ b/server.js
@@ -5402,6 +5402,53 @@ init().then(async () => {
     return `<?xml version="1.0"?><?mso-application progid="Excel.Sheet"?><Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"><Worksheet ss:Name="Current Balances"><Table>${summaryRows.join('')}</Table></Worksheet><Worksheet ss:Name="Leave History"><Table>${historyRows.join('')}</Table></Worksheet></Workbook>`;
   }
 
+  function cleanLeaveTableForResetData(data) {
+    data.applications = Array.isArray(data.applications) ? data.applications : [];
+    data.employees = Array.isArray(data.employees) ? data.employees : [];
+
+    const removedApplications = data.applications.length;
+    data.applications = [];
+
+    let updatedEmployees = 0;
+    const resetTimestamp = new Date().toISOString();
+    data.employees.forEach(emp => {
+      if (!emp || typeof emp !== 'object') return;
+      const balances = cloneDefaultLeaveBalances();
+      SUPPORTED_LEAVE_TYPES.forEach(type => {
+        const previous = emp.leaveBalances?.[type] && typeof emp.leaveBalances[type] === 'object'
+          ? emp.leaveBalances[type]
+          : {};
+        const yearlyAllocation = Number.isFinite(Number(previous.yearlyAllocation))
+          ? Number(previous.yearlyAllocation)
+          : DEFAULT_LEAVE_BALANCES[type].yearlyAllocation;
+        balances[type] = {
+          ...DEFAULT_LEAVE_BALANCES[type],
+          yearlyAllocation,
+          monthlyAccrual: yearlyAllocation / 12,
+          accrued: 0,
+          taken: 0,
+          balance: 0,
+          manualAdjustment: 0
+        };
+      });
+      balances.cycleStart = emp.leaveBalances?.cycleStart || null;
+      balances.cycleEnd = emp.leaveBalances?.cycleEnd || null;
+      balances.lastAccrualRun = null;
+      balances.lastManualResetAt = resetTimestamp;
+      balances.cycleDurationMonths = emp.leaveBalances?.cycleDurationMonths || getLeaveCycleSettings(data.settings?.leaveCycle).durationMonths;
+      const changed = JSON.stringify(emp.leaveBalances || {}) !== JSON.stringify(balances);
+      emp.leaveBalances = balances;
+      if (changed) updatedEmployees += 1;
+    });
+
+    data.settings = data.settings && typeof data.settings === 'object' ? data.settings : {};
+    data.settings.leaveCycle = data.settings.leaveCycle && typeof data.settings.leaveCycle === 'object'
+      ? { ...data.settings.leaveCycle, lastManualResetAt: resetTimestamp }
+      : { lastManualResetAt: resetTimestamp };
+
+    return { removedApplications, updatedEmployees, processedEmployees: data.employees.length, resetTimestamp };
+  }
+
   app.put('/settings/leave', authRequired, managerOnly, async (req, res) => {
     try {
       const requestedDuration = Number(req.body?.durationMonths);
@@ -5502,6 +5549,18 @@ init().then(async () => {
     } catch (err) {
       console.error('Failed to reset leave balances', err);
       res.status(500).json({ error: 'Unable to reset leave balances.' });
+    }
+  });
+
+  app.post('/settings/leave/reset/clean-table', authRequired, managerOnly, async (_req, res) => {
+    try {
+      await db.read();
+      const result = cleanLeaveTableForResetData(db.data);
+      await db.write();
+      res.json(result);
+    } catch (err) {
+      console.error('Failed to clean leave table for reset', err);
+      res.status(500).json({ error: 'Unable to clean leave table.' });
     }
   });
 


### PR DESCRIPTION
### Motivation
- Old leave application rows can leave non-zero "taken" values after a cycle reset, so operators need a safe way to clear historical leave rows and force all employee leave balances to 0/0/0.
- The settings subtab label was incorrect (`Rest`) and should read `Reset` for clarity.

### Description
- Renamed the Settings subtab label from “Rest” to `Reset` in `public/index.html` and updated the Reset panel copy. 
- Added a "Clean leave table for reset" button and helper text in the Reset panel and implemented a front-end handler `onCleanLeaveTableForReset` with confirmation, status updates, and an API call in `public/index.js`.
- Added a manager-only server-side cleanup helper `cleanLeaveTableForResetData` and a POST endpoint `POST /settings/leave/reset/clean-table` that clears `applications` and resets per-employee `leaveBalances` (accrued/taken/balance/manualAdjustment → 0) in `server.js`.
- Introduced a reusable CLI script `scripts/cleanLeaveTableForReset.js` and exposed it as `npm run clean:leave-table` to allow one-off command-line cleanup operations.

### Testing
- Syntax checks: `node --check server.js`, `node --check public/index.js`, and `node --check scripts/cleanLeaveTableForReset.js` all completed without errors. (succeeded)
- Unit tests: ran `npm test` (`node --test`) which executed the leave accrual tests and reported `16` passing tests and `0` failures. (succeeded)
- Manual smoke: exercised the new Reset UI flow and confirmed the front-end adds the button and triggers the API call (UI wiring added and event listener registered). (observational)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a421eea1abc8331a4e21d8e0f3a6e70)