### PR TITLE
Fix leave balance reset calculations

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,7 +57,6 @@ const {
 } = require('./services/learningRoleAssignmentService');
 const { getUploadsRoot } = require('./utils/uploadPaths');
 const {
-  computeAllLeaveBalances,
   getCurrentLeaveCycle: getCurrentLeaveCycleInfo,
   DEFAULT_ENTITLEMENTS
 } = require('./utils/leaveAccrual');
@@ -1774,7 +1773,12 @@ function refreshEmployeeLeaveBalances(employee, data, options = {}) {
 function formatLeaveBalancesForResponse(balances, { dateNow = new Date(), settings } = {}) {
   const cycle = getCurrentLeaveCycleInfo(dateNow, settings);
   const toEntry = (entry = {}, defaultEntitlement = 0) => {
-    const entitlement = Number.isFinite(entry?.entitlement) ? entry.entitlement : defaultEntitlement;
+    const yearlyAllocation = Number(entry?.yearlyAllocation);
+    const entitlement = Number.isFinite(entry?.entitlement)
+      ? entry.entitlement
+      : Number.isFinite(yearlyAllocation)
+        ? yearlyAllocation
+        : defaultEntitlement;
     const earned = roundToOneDecimal(entry?.earned || entry?.accrued || 0);
     const adjustment = roundToOneDecimal(entry?.manualAdjustment ?? entry?.adjustment ?? 0);
     return {
@@ -1803,11 +1807,14 @@ function formatLeaveBalancesForResponse(balances, { dateNow = new Date(), settin
 async function getComputedLeaveBalances(employee, options = {}) {
   if (!employee) return { raw: null, formatted: null };
   const dateNow = options.dateNow instanceof Date ? options.dateNow : new Date();
-  const balances = await computeAllLeaveBalances(employee, {
-    dateNow,
-    applications: options.applications || (db.data && db.data.applications),
-    holidays: options.holidays || (db.data && db.data.holidays),
-    settings: options.settings || (db.data && db.data.settings)
+  const settings = options.settings || (db.data && db.data.settings) || {};
+  const cycleSettings = getLeaveCycleSettings(settings);
+  const cycleRange = options.cycleRange || getCurrentCycleRange(dateNow, cycleSettings);
+  const { balances } = buildEmployeeLeaveState(employee, options.applications || (db.data && db.data.applications) || [], {
+    asOfDate: dateNow,
+    cycleRange,
+    holidays: options.holidays || (db.data && db.data.holidays) || [],
+    settings: cycleSettings
   });
 
   return {


### PR DESCRIPTION
### Motivation
- The API was returning computed leave balances that ignored a recent manual reset because the read/display path used the older `computeAllLeaveBalances` logic instead of the reset-aware flow used when refreshing stored balances. 
- This caused post-reset displays to show incorrect balances by counting pre-reset applications and not preserving per-employee yearly allocations.

### Description
- Use the reset-aware calculation path by calling `buildEmployeeLeaveState` (with `getLeaveCycleSettings` and `getCurrentCycleRange`) inside `getComputedLeaveBalances` so manual resets (`lastManualResetAt`) and accrual resume rules are respected. 
- Preserve custom per-employee `yearlyAllocation` when formatting the response so entitlement no longer falls back to defaults incorrectly. 
- Remove the now-unused `computeAllLeaveBalances` import from `server.js` to avoid mixing calculation paths.

### Testing
- Ran `npm test` which executed the suite and reported all unit tests passing (`16` tests passed, `0` failed). 
- An earlier attempt to run `npm test -- --runInBand` failed because the Node test runner does not accept the `--runInBand` option, which is a test runner invocation issue rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4229cf5e4083318958f4990bd480c7)