### PR TITLE
Hide inactive employees in UI and enforce employee active checks during auth/login

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -11823,9 +11823,10 @@ async function getJSON(path) {
 
 async function loadEmployeesPortal() {
   const emps = await getJSON('/employees');
-  let filteredEmps = emps;
+  const activeEmps = Array.isArray(emps) ? emps.filter(isEmployeeActive) : [];
+  let filteredEmps = activeEmps;
   if (currentUser && !isManagerRole(currentUser)) {
-    filteredEmps = emps.filter(e => e.id == currentUser.employeeId);
+    filteredEmps = activeEmps.filter(e => e.id == currentUser.employeeId);
   }
   ['employeeSelect', 'reportSelect'].forEach(id => {
     const sel = document.getElementById(id);

--- a/server.js
+++ b/server.js
@@ -3080,7 +3080,7 @@ async function authRequired(req, res, next) {
   const token = resolveToken(req);
   const user = await resolveUserFromSession(token);
   if (user) {
-    if (!isManagerRole(user.role)) {
+    if (user.employeeId !== null && typeof user.employeeId !== 'undefined') {
       const employees = Array.isArray(db.data.employees) ? db.data.employees : [];
       const emp = employees.find(e => e.id == user.employeeId);
       if (!isEmployeeActive(emp)) {
@@ -3199,6 +3199,11 @@ init().then(async () => {
       let user = db.data.users?.find(u => u.email === email);
       let userObj;
       if (user) {
+        const employees = Array.isArray(db.data.employees) ? db.data.employees : [];
+        const emp = employees.find(e => e.id == user.employeeId);
+        if (!isEmployeeActive(emp)) {
+          return res.status(403).send('Employee account is inactive');
+        }
         userObj = { id: user.id, email: user.email, role: user.role, employeeId: user.employeeId };
       } else if (email === ADMIN_EMAIL) {
         userObj = { id: 'admin', email: ADMIN_EMAIL, role: 'superadmin', employeeId: null };
@@ -3444,12 +3449,10 @@ init().then(async () => {
 
     let userObj;
     if (user) {
-      if (!isManagerRole(user.role)) {
-        const employees = Array.isArray(db.data.employees) ? db.data.employees : [];
-        const emp = employees.find(e => e.id == user.employeeId);
-        if (!isEmployeeActive(emp)) {
-          return res.status(403).json({ error: 'Employee account is inactive' });
-        }
+      const employees = Array.isArray(db.data.employees) ? db.data.employees : [];
+      const emp = employees.find(e => e.id == user.employeeId);
+      if (!isEmployeeActive(emp)) {
+        return res.status(403).json({ error: 'Employee account is inactive' });
       }
       userObj = {
         id: user.id,


### PR DESCRIPTION
### Motivation

- Prevent inactive employee records from appearing in the portal dropdowns and from being used to authenticate.  
- Ensure users tied to employee records cannot sign in or use sessions if their employee account is inactive.

### Description

- In `public/index.js` `loadEmployeesPortal` now builds `activeEmps` via `Array.isArray(emps) ? emps.filter(isEmployeeActive) : []` and uses that list for the `employeeSelect` and `reportSelect` options so inactive employees are omitted.  
- In `server.js` the `authRequired` middleware was changed to only perform the active-employee check when `user.employeeId` is present, and it clears the session and cookie and returns `403` if the linked employee is inactive.  
- The Microsoft OAuth callback now rejects login with `403` when the resolved user is linked to an inactive employee.  
- The `/login` endpoint now verifies the linked employee is active for users tied to an employee and returns `403` if the employee is inactive.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a423367abb88331bc2ad0c5a7959bc4)