### PR TITLE
Fix first-day leave accrual

### DIFF
--- a/cron/resetLeaveCycle.js
+++ b/cron/resetLeaveCycle.js
@@ -57,7 +57,7 @@ async function resetLeaveCycle(now = new Date()) {
   return { processed: employees.length, updated: updatedCount };
 }
 
-const resetLeaveCycleJob = cron.schedule('0 1 1 1,7 *', async () => {
+const resetLeaveCycleJob = cron.schedule('0 0 1 1,7 *', async () => {
   console.log('[CRON] Starting leave cycle reset job');
   try {
     const result = await resetLeaveCycle();

--- a/services/leaveAccrualService.js
+++ b/services/leaveAccrualService.js
@@ -336,7 +336,15 @@ function listAccrualMonths(window, asOfDate) {
     const monthEnd = getMonthEnd(cursor);
     const activeStart = cursor < window.effectiveStart ? window.effectiveStart : cursor;
     const activeEnd = monthEnd > window.effectiveEnd ? window.effectiveEnd : monthEnd;
-    const accrualBoundary = monthEnd < accrualEnd ? monthEnd : accrualEnd;
+    const isMonthlyAccrualDate =
+      cutoffDate.getDate() === 1 &&
+      cursor.getFullYear() === cutoffDate.getFullYear() &&
+      cursor.getMonth() === cutoffDate.getMonth();
+    const accrualBoundary = isMonthlyAccrualDate
+      ? monthEnd
+      : monthEnd < accrualEnd
+        ? monthEnd
+        : accrualEnd;
 
     if (accrualBoundary >= activeStart) {
       const boundedEnd = activeEnd < accrualBoundary ? activeEnd : accrualBoundary;

--- a/services/leaveAccrualService.test.js
+++ b/services/leaveAccrualService.test.js
@@ -229,6 +229,17 @@ test('Normalization caps stored balances and accrued values at allocations', () 
 });
 
 
+
+test('Cycle start immediately grants the first monthly leave increment', () => {
+  const asOfDate = new Date('2026-07-01T00:10:00Z');
+  const employee = createEmployee(new Date('2020-01-01'));
+  const balances = runState(employee, [], asOfDate);
+
+  assert.equal(balances.annual.balance, roundToOneDecimal(10 / 12));
+  assert.equal(balances.casual.balance, roundToOneDecimal(5 / 12));
+  assert.equal(balances.medical.balance, roundToOneDecimal(14 / 12));
+});
+
 test('Six month leave cycles use Jan-Jun and Jul-Dec boundaries', () => {
   const firstHalf = getCurrentCycleRange(new Date('2026-03-15'), { durationMonths: 6 });
   assert.equal(firstHalf.start.toISOString().slice(0, 10), '2026-01-01');


### PR DESCRIPTION
### Motivation
- New leave cycles that start on the 1st of a month were not showing the first monthly increment immediately because the accrual logic treated the current month as partially earned, and the cycle reset cron could run after the monthly accrual and wipe the increment.

### Description
- Adjust `listAccrualMonths` in `services/leaveAccrualService.js` to treat recalculations performed on the 1st of a month as granting the full current month's accrual by expanding the `accrualBoundary` when `cutoffDate.getDate() === 1`.
- Change the leave cycle reset cron in `cron/resetLeaveCycle.js` from `cron.schedule('0 1 1 1,7 *'` to `cron.schedule('0 0 1 1,7 *'` so the reset runs at midnight before the monthly accrual job.
- Add a regression test `Cycle start immediately grants the first monthly leave increment` to `services/leaveAccrualService.test.js` that verifies balances on `2026-07-01T00:10:00Z` include the first monthly increment.

### Testing
- Ran the test suite with `npm test` (runs `node --test`) and all tests passed with `# pass 17` and `# fail 0`.
- The newly added regression test passed as part of the run, confirming the July 1 incremental accrual behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a449642c60c833187b5a023dc90f607)